### PR TITLE
Feature/refactor personas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,9 @@ The framework is configured through three user-supplied files (templates ship as
 * **Agent Skills** (`fetch_agent_skill`, `run_agent_skill_script`): Discover and execute
   skills installed under `AGENT_SKILLS_ROOT`, following the
   [agentskills.io](https://agentskills.io/specification) progressive-disclosure model.
+  `fetch_agent_skill` returns `SKILL.md` and a `references/` manifest first; pass
+  `include_references=true` with a specific `reference_path` only when detailed reference
+  material is required.
 * **Screenshots & Reproductions**: The screenshot tool captures full-page bug evidence and
   is thread-aware via `RunnableConfig`. The browser engine translates Action Tape entries
   into reproducible Playwright specs.
@@ -167,8 +170,15 @@ Every mission generates artifacts localized in a `report_<thread_id>/` directory
 * `screenshots/`: Full-page screenshots captured when bugs are detected.
 
 ## Conventions When Changing Code
+* **Context Disclosure Rule**: Keep prompts compact enough for regular Opus-class context
+  windows. Do not replay full histories unless absolutely necessary. The supervisor routes
+  from a compact mission brief, recent progress, recent Action Tape entries, bugs, and
+  explored URLs. Report generation preserves the start and latest outcome of long transcripts
+  while omitting the middle. PR scenario generation sends a budgeted diff excerpt rather than
+  the full diff. Tunables: `PR_PROMPT_DIFF_BUDGET_CHARS`, `PR_PROMPT_BODY_BUDGET_CHARS`,
+  `PR_PROMPT_FILE_LIST_LIMIT`, and `PR_GENERATED_MISSION_PROMPT_MAX_CHARS`.
 * **Global QA Rule**: Strictly enforced in
-  `src/agentic_explorer/orchestration/standard_graph.py` and `advanced_graph.py` — agents
+  `src/agentic_explorer/orchestration/graph_base.py` via compact shared prompt helpers — agents
   must consult MCP/Skills first when available, never guess, and capture screenshot evidence
   + call `generate_reproduction_spec` immediately on failures.
 * **Selector Policy (Engine-Enforced)**: `execute_browser_command` rejects brittle selectors

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ Supported JSON actions: `navigate`, `click`, `fill`, `press`, `select_option`, `
 
 ### Agent Types
 `main.py` automatically compiles either a standard or advanced graph based on `thread_id`
-keywords (`explorer`, `chaos`, `autonomous` → advanced; everything else → standard).
+keywords (`accessibility`, `a11y`, `data_heavy`, `data-heavy`, `impatient`, `returning`,
+`explorer`, `chaos`, `autonomous` → advanced; everything else → standard).
 
 ### PR-Driven Scenario Generation
 `src/agentic_explorer/pr_analyzer.py` provides a pipeline that sits **before** mission
@@ -57,35 +58,25 @@ execution:
 The generated missions follow the standard YAML format and are routed to agents via the same
 `thread_id`-keyword mechanism. Thread IDs use the convention `pr_{number}_{agenttype}_{nn}`.
 
-* **Standard QA Agents** (`src/agentic_explorer/orchestration/standard_graph.py`): Thirteen agents available for routing by the supervisor:
-  * **5 UI-pattern specialists**: Tools are split by modality (DOM-only vs. visual validation).
-    * `listing_agent` (DOM tools) — lists, tables, search/filter bars, pagination, row flyouts.
-    * `graph_agent` (DOM + visual) — node-link graphs, timelines, waterfalls, complex SVG/Canvas.
-    * `chart_agent` (DOM + visual) — time-series, bar/line/area charts, KPI tiles, dashboards.
-    * `map_agent` (DOM + visual) — geographic maps, status grids, geospatial overlays.
-    * `form_agent` (DOM tools) — forms, wizards, validation flows, multi-step configuration.
-  * **8 Generic Exploration Personas**: These personas apply behavioral strategies to the application.
-    * `new_user_agent` — tests onboarding flows, discoverability, default states, and empty states.
-    * `power_user_agent` — uses keyboard shortcuts, bulk operations, advanced filters, edge-case workflows.
-    * `adversarial_user_agent` — deliberately tries to break things (invalid inputs, back-button abuse).
-    * `impatient_user_agent` — cancels operations mid-flight, refreshes during submissions, clicks buttons multiple times.
-    * `accessibility_user_agent` — validates WCAG compliance, screen reader navigation, keyboard-only interaction.
-    * `constrained_user_agent` — tests degraded-experience paths and responsive design for slow networks and small viewports.
-    * `data_heavy_user_agent` — uploads large files, creates thousands of records, uses long strings.
-    * `returning_user_agent` — scenarios for returning users with stale sessions, cached pages, outdated bookmarks.
+* **Standard QA Agents** (`src/agentic_explorer/orchestration/standard_graph.py`): Three agents available for routing by the supervisor:
+  * `new_user_agent` — tests onboarding flows, discoverability, default states, and empty states.
+  * `power_user_agent` — uses keyboard shortcuts, bulk operations, advanced filters, edge-case workflows.
+  * `adversarial_user_agent` — deliberately tries to break things (invalid inputs, back-button abuse).
 * **Advanced Testing Agents** (`src/agentic_explorer/orchestration/advanced_graph.py`):
-    * `explorer_agent` — autonomous chaos exploration; uses the full Record-and-Translate
-      engine. The advanced graph's single-agent supervisor is preserved as an extension point
-      for additional specialized agents.
+  * `accessibility_user_agent` — validates WCAG compliance, screen reader navigation, keyboard-only interaction.
+  * `data_heavy_user_agent` — uploads large files, creates thousands of records, uses long strings.
+  * `impatient_user_agent` — cancels operations mid-flight, refreshes during submissions, clicks buttons multiple times.
+  * `returning_user_agent` — scenarios for returning users with stale sessions, cached pages, outdated bookmarks.
+  * `explorer_agent` — autonomous chaos exploration; uses the full Record-and-Translate engine.
 
 ### State Management
 * **Persistent Memory**: State is persisted via an SQLite checkpointer (`agent_memory.sqlite`),
   keyed by the `thread_id`.
 * **Mission Isolation**: Each mission has a unique `thread_id` to isolate its memory; reusing a
   thread ID resumes the prior context.
-* **`AgentState` / `AdvancedAgentState`**: Both state TypedDicts carry `messages`,
-  `next_agent`, `step_count`, and `action_tape` (an append-only list of recorded browser
-  commands).
+* **`AgentState`**: A unified state `TypedDict` that carries `messages`,
+  `next_agent`, `step_count`, `action_tape` (an append-only list of recorded browser
+  commands), `bugs_found`, and `explored_paths`.
 
 ## Configuration Surface
 The framework is configured through three user-supplied files (templates ship as
@@ -98,9 +89,9 @@ The framework is configured through three user-supplied files (templates ship as
   leave it unset and the framework loads `~/.gemini/oauth_creds.json` (produced by
   `gemini auth login`). Set `LLM_PROVIDER` to force a specific provider.
   Optional: `APP_CONFIG`, `MCP_SERVERS_CONFIG`, `AGENT_SKILLS_ROOT`,
-  `AGENT_SKILL_SCRIPT_TIMEOUT`, `CLAUDE_MODEL`, `CLAUDE_VISION_MODEL`,
+  `AGENT_SKILL_SCRIPT_TIMEOUT`, `ANTHROPIC_VERTEX_REGION`, `CLAUDE_MODEL`, `CLAUDE_VISION_MODEL`,
   `CLAUDE_REPORT_MODEL`, `CLAUDE_SCENARIO_MODEL`, `GEMINI_MODEL`, `GEMINI_VISION_MODEL`,
-  `GEMINI_REPORT_MODEL`, `GEMINI_SCENARIO_MODEL`.
+  `GEMINI_REPORT_MODEL`, `GEMINI_SCENARIO_MODEL`, `SCENARIO_MODEL` (provider-agnostic).
 * **`config.yaml`** (loaded by `src/agentic_explorer/config.py`) — `app.{name,url,description}`,
   `auth.{method,selectors,post_login_check}`, `paths.{mcp_servers,skills_root}`,
   `llm.{provider,claude_model,gemini_model,claude_vision_model,gemini_vision_model}`.
@@ -129,14 +120,14 @@ The framework is configured through three user-supplied files (templates ship as
 * **Agent Skills** (`fetch_agent_skill`, `run_agent_skill_script`): Discover and execute
   skills installed under `AGENT_SKILLS_ROOT`, following the
   [agentskills.io](https://agentskills.io/specification) progressive-disclosure model.
-* **Vision & Screenshots**: The screenshot tool captures full-page bug evidence and is
-  thread-aware via `RunnableConfig`. The `analyze_visual_state` tool uses the configured
-  AI vision model (Claude or Gemini) to validate UI rendering.
+* **Screenshots & Reproductions**: The screenshot tool captures full-page bug evidence and
+  is thread-aware via `RunnableConfig`. The browser engine translates Action Tape entries
+  into reproducible Playwright specs.
 
 ## Running the System
 
 ### Initial Setup
-1. **Install dependencies**: `pip install -r requirements.txt` (or `uv pip install -r requirements.txt`).
+1. **Install dependencies**: `pip install -e .` (or `uv pip install -e .`).
    Re-run this after every `git pull` to pick up new or updated packages. Key packages:
    `langchain`, `langchain-anthropic`, `langchain-google-genai`, `langchain-google-vertexai`,
    `langgraph`, `playwright`, `python-dotenv`, `pyyaml`, `pillow`, `langchain-mcp-adapters`,
@@ -149,11 +140,11 @@ The framework is configured through three user-supplied files (templates ship as
 
 ### Developer Workflows
 Execute missions defined in YAML format (see `missions/README.md`):
-* **Standard Run**: `agent-explorer --missions missions/listing_agent.yaml`
-* **Explicit Provider**: `agent-explorer --missions missions/listing_agent.yaml --provider claude`
-* **Headed Mode** (Debugging): `agent-explorer --missions missions/listing_agent.yaml --headed`
-* **Clear Memory**: `agent-explorer --missions missions/listing_agent.yaml --clear-memory`
-* **Custom Step Limit**: `agent-explorer --missions missions/listing_agent.yaml --max-steps 50`
+* **Standard Run**: `agent-explorer --missions missions/new_user_agent.yaml`
+* **Explicit Provider**: `agent-explorer --missions missions/power_user_agent.yaml --provider claude`
+* **Headed Mode** (Debugging): `agent-explorer --missions missions/accessibility_user_agent.yaml --headed`
+* **Clear Memory**: `agent-explorer --missions missions/new_user_agent.yaml --clear-memory`
+* **Custom Step Limit**: `agent-explorer --missions missions/new_user_agent.yaml --max-steps 50`
   (default: 30; supervisor resets to the app homepage on limit and tries a new strategy)
 
 PR-driven test generation (prefers GitHub MCP server; falls back to [`gh` CLI](https://cli.github.com/)):
@@ -161,7 +152,7 @@ PR-driven test generation (prefers GitHub MCP server; falls back to [`gh` CLI](h
   — writes `missions/pr_123.yaml`
 * **Generate + Execute**: `agent-explorer --pr-url https://github.com/org/repo/pull/123 --execute --headed`
 * **Custom Output Dir**: `agent-explorer --pr-url <url> --output-dir ./pr-missions`
-* **Combined**: `agent-explorer --missions missions/listing_agent.yaml --pr-url <url> --execute`
+* **Combined**: `agent-explorer --missions missions/new_user_agent.yaml --pr-url <url> --execute`
   — runs both hand-written and auto-generated missions
 
 ## Output Artifacts
@@ -188,13 +179,14 @@ Every mission generates artifacts localized in a `report_<thread_id>/` directory
     * **Forbidden**: XPath (`//div`), positional CSS (`:nth-child(3)`,
       `div > span:nth-of-type(2)`). Always call `get_dom_snapshot` first.
 * **Agent Modification**: If adding a new agent, you must update the system prompt, tool
-  bundle, node wrapper function, supervisor enum, and conditional routing table.
+  bundle, agent registry, supervisor descriptions, and routing keywords when applicable.
 * **Mission Modifications**: If adding a new advanced mission category, update both the
   mission `thread_id` naming and the `ADVANCED_KEYWORDS` tuple in `main.py`.
 * **PR Analyzer Modifications**: The PR scenario generation prompt is in
   `src/agentic_explorer/pr_analyzer.py` (`_SYSTEM_PROMPT`). When adding a new agent type,
-  also add its description to this prompt so the LLM can route PR changes to it. Generated
-  thread IDs must follow `pr_{number}_{agenttype}_{nn}` and respect `ADVANCED_KEYWORDS`.
+  also add its description to this prompt and update PR mission validation so the LLM can
+  route PR changes to it. Generated thread IDs must follow `pr_{number}_{agenttype}_{nn}`
+  and respect `ADVANCED_KEYWORDS`.
 * **LLM Configuration**: The system supports Claude (default) and Gemini providers. The
   provider is auto-detected from credentials or set explicitly via `LLM_PROVIDER` env var,
   `--provider` CLI flag, or `config.yaml > llm.provider`. Smart model defaults are chosen

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ to find bugs, render anomalies, and unscripted edge cases.
 
 Powered by a **LangGraph Swarm** architecture, **Playwright**, and your choice of
 **Claude** (default) or **Google Gemini**, this framework dynamically routes tasks to
-UI-pattern specialists, visually validates complex charts, self-heals from UI errors,
+behavioral QA personas and advanced stress/exploration agents, self-heals from UI errors,
 optionally consults user-provided MCP servers and Agent Skills for domain knowledge,
 generates reproducible Playwright test scripts from every bug found, and writes Markdown
 executive test reports.
@@ -44,23 +44,17 @@ graph TD
     Main -->|Checkpoints| DB[(SQLite Memory)]:::db
 
     subgraph SQA [Standard QA Swarm]
-        S_Supervisor <-->|Routes & Returns| S_List([Listing Agent]):::agent
-        S_Supervisor <--> S_Graph([Graph Agent]):::agent
-        S_Supervisor <--> S_Chart([Chart Agent]):::agent
-        S_Supervisor <--> S_Map([Map Agent]):::agent
-        S_Supervisor <--> S_Form([Form Agent]):::agent
-        S_Supervisor <--> S_New([New User Agent]):::agent
+        S_Supervisor <-->|Routes & Returns| S_New([New User Agent]):::agent
         S_Supervisor <--> S_Power([Power User Agent]):::agent
         S_Supervisor <--> S_Adv([Adversarial User Agent]):::agent
-        S_Supervisor <--> S_Imp([Impatient User Agent]):::agent
-        S_Supervisor <--> S_Acc([Accessibility User Agent]):::agent
-        S_Supervisor <--> S_Con([Constrained User Agent]):::agent
-        S_Supervisor <--> S_Data([Data Heavy User Agent]):::agent
-        S_Supervisor <--> S_Ret([Returning User Agent]):::agent
     end
 
     subgraph ATS [Advanced Testing Swarm]
-        A_Supervisor <-->|Routes & Returns| A_Explorer([Explorer Agent]):::agent
+        A_Supervisor <-->|Routes & Returns| A_Acc([Accessibility User Agent]):::agent
+        A_Supervisor <--> A_Data([Data Heavy User Agent]):::agent
+        A_Supervisor <--> A_Imp([Impatient User Agent]):::agent
+        A_Supervisor <--> A_Ret([Returning User Agent]):::agent
+        A_Supervisor <--> A_Explorer([Explorer Agent]):::agent
     end
 
     SQA --> Tools[[Tools & APIs]]:::tool
@@ -69,7 +63,6 @@ graph TD
     subgraph Integrations [External Integrations]
         Tools -->|JSON Intents / Action Tape| Engine[Browser Engine]:::external
         Engine -->|Playwright| PW[Chromium]:::external
-        Tools -->|Visual Validation| Vision[AI Vision]:::external
         Tools -->|Optional Docs/Knowledge| MCP[User-configured MCP Servers]:::external
         Tools -->|Optional Skills| Skills[User-installed Agent Skills]:::external
         Tools -->|UI under test| WebApp[Your Web Application]:::external
@@ -84,9 +77,10 @@ graph TD
 
 1. **Mission Dispatcher (`main.py`)**: Loads `missions/*.yaml` files and provisions the
    correct graph network based on `thread_id` naming conventions
-   (`explorer` / `chaos` / `autonomous` route to the advanced graph; everything else to the
-   standard 13-agent swarm). Can also accept a `--pr-url` to auto-generate missions from a
-   GitHub Pull Request via `pr_analyzer.py`.
+   (`accessibility`, `data_heavy`, `impatient`, `returning`, `explorer`, `chaos`, or
+   `autonomous` route to the advanced graph; everything else to the standard 3-persona
+   swarm). Can also accept a `--pr-url` to auto-generate missions from a GitHub Pull
+   Request via `pr_analyzer.py`.
 2. **Supervisor-Worker Flow**: A Supervisor node dynamically evaluates the workspace state
    and dispatches control to specialized worker nodes.
 3. **Record-and-Translate Browser Engine** (`src/agentic_explorer/tools/browser/engine.py`):
@@ -100,8 +94,8 @@ graph TD
      (`report_<thread_id>/action_tape.jsonl`).
    - On bug detection, `generate_reproduction_spec` translates the tape into a runnable
      `reproduction_*.spec.ts` Playwright test.
-4. **Tool Modality**: Agents receive (1) the deterministic browser engine, (2) AI Vision
-   (Claude or Gemini) for perceptual validation, (3) any **MCP servers you configure** in
+4. **Tool Modality**: Agents receive (1) the deterministic browser engine, (2) screenshot
+   capture and reproduction-generation tools, (3) any **MCP servers you configure** in
    `mcp_servers.json`, and (4) any **Agent Skills** installed under `AGENT_SKILLS_ROOT`.
    The framework ships zero hardcoded MCP servers or skills — bring your own.
 5. **State & Memory (`agent_memory.sqlite`)**: An asynchronous SQLite checkpointer
@@ -120,10 +114,10 @@ graph TD
 - `src/agentic_explorer/utils/llm_json.py` — YAML/JSON extraction helpers for LLM responses
 - `src/agentic_explorer/orchestration/graph_base.py` — shared graph infrastructure
   (`AgentState`, node factories, tool filtering)
-- `src/agentic_explorer/orchestration/standard_graph.py` — 13 standard QA agents (5 specialists, 8 personas)
-- `src/agentic_explorer/orchestration/advanced_graph.py` — autonomous explorer agent
+- `src/agentic_explorer/orchestration/standard_graph.py` — 3 standard QA personas
+- `src/agentic_explorer/orchestration/advanced_graph.py` — 4 advanced personas plus autonomous explorer
 - `src/agentic_explorer/tools/browser/engine.py` — Record-and-Translate browser engine
-- `src/agentic_explorer/tools/common/custom_tools.py` — vision, screenshot, MCP loader,
+- `src/agentic_explorer/tools/common/custom_tools.py` — screenshot, MCP loader,
   Skills tools
 
 ---
@@ -131,8 +125,8 @@ graph TD
 ## ✨ Key Features
 
 * **Product-Agnostic**: One small `config.yaml` adapts the framework to any web app.
-* **UI-Pattern Specialist & Persona Agents**: Thirteen standard QA agents (UI-pattern specialists and behavioral personas)
-  + an autonomous explorer — each prompted around a specific testing strategy.
+* **Persona-Driven QA Agents**: Three standard QA personas plus five advanced agents —
+  each prompted around a specific testing strategy.
 * **Record-and-Translate Engine**: Agents emit JSON intents, the deterministic engine
   executes and records every step to an immutable Action Tape. Every bug automatically
   generates a reproducible `reproduction_*.spec.ts` Playwright script.
@@ -141,8 +135,8 @@ graph TD
   `data-test-subj` → `aria-label` → visible text priority.
 * **Self-Healing Browser Execution**: Playwright actions are wrapped to catch uncaught
   exceptions. Errors are returned as natural language so agents can adapt strategies.
-* **Visual Validation**: Agents can take screenshots of complex Canvas/SVG elements and
-  use AI vision (Claude or Gemini) to analyze them for rendering anomalies.
+* **Screenshot Evidence**: Agents capture full-page screenshots when bugs or anomalies are
+  detected, then generate reproducible Playwright specs from the Action Tape.
 * **Bring-Your-Own MCP**: Plug in any MCP servers via a standard
   `mcp_servers.json` — agents query them for domain knowledge instead of guessing.
 * **Bring-Your-Own Skills**: Install Agent Skills (per the
@@ -335,12 +329,16 @@ your app's login form.
 ### Defining Missions
 
 Missions live in `missions/*.yaml`. See [`missions/README.md`](missions/README.md) for the
-schema and writing guide. Fourteen templates ship in the repo, one for each defined agent persona:
+schema and writing guide. Eight templates ship in the repo, one for each supported agent:
 
-- [`missions/listing_agent.yaml`](missions/listing_agent.yaml)
-- [`missions/form_agent.yaml`](missions/form_agent.yaml)
+- [`missions/new_user_agent.yaml`](missions/new_user_agent.yaml)
+- [`missions/power_user_agent.yaml`](missions/power_user_agent.yaml)
+- [`missions/adversarial_user_agent.yaml`](missions/adversarial_user_agent.yaml)
+- [`missions/accessibility_user_agent.yaml`](missions/accessibility_user_agent.yaml)
+- [`missions/data_heavy_user_agent.yaml`](missions/data_heavy_user_agent.yaml)
+- [`missions/impatient_user_agent.yaml`](missions/impatient_user_agent.yaml)
+- [`missions/returning_user_agent.yaml`](missions/returning_user_agent.yaml)
 - [`missions/explorer_agent.yaml`](missions/explorer_agent.yaml)
-- etc.
 
 All of them contain placeholders (`<YOUR_APP>`, `<APP_URL>`, `<example_search_term>`, …) — fill
 them in for your application before running.
@@ -348,24 +346,27 @@ them in for your application before running.
 ### Running Missions from YAML
 
 ```bash
-# Standard 13-agent QA swarm (uses auto-detected provider — Claude by default)
-agent-explorer --missions missions/listing_agent.yaml
+# Standard 3-persona QA swarm (uses auto-detected provider — Claude by default)
+agent-explorer --missions missions/new_user_agent.yaml
 
 # Explicitly choose a provider
-agent-explorer --missions missions/form_agent.yaml --provider claude
-agent-explorer --missions missions/form_agent.yaml --provider gemini
+agent-explorer --missions missions/power_user_agent.yaml --provider claude
+agent-explorer --missions missions/power_user_agent.yaml --provider gemini
+
+# Advanced persona mission
+agent-explorer --missions missions/accessibility_user_agent.yaml --headed
 
 # Autonomous exploration (visible browser recommended)
 agent-explorer --missions missions/explorer_agent.yaml --headed
 
 # Clear agent memory to restart fresh
-agent-explorer --missions missions/listing_agent.yaml --clear-memory
+agent-explorer --missions missions/new_user_agent.yaml --clear-memory
 
 # Override the supervisor step limit (default: 30)
-agent-explorer --missions missions/listing_agent.yaml --max-steps 50
+agent-explorer --missions missions/new_user_agent.yaml --max-steps 50
 
 # Suppress verbose ReAct console output (traces.log still captures everything)
-agent-explorer --missions missions/listing_agent.yaml --quiet
+agent-explorer --missions missions/new_user_agent.yaml --quiet
 ```
 
 ### PR-Driven Test Generation
@@ -388,14 +389,14 @@ agent-explorer --pr-url https://github.com/org/repo/pull/123 --execute --headed
 agent-explorer --pr-url https://github.com/org/repo/pull/123 --output-dir ./pr-missions
 
 # Combine with existing missions
-agent-explorer --missions missions/listing_agent.yaml --pr-url https://github.com/org/repo/pull/123 --execute
+agent-explorer --missions missions/new_user_agent.yaml --pr-url https://github.com/org/repo/pull/123 --execute
 ```
 
 The analyzer extracts the PR title, description, file list, and full code diff, then sends
 them along with the app context from `config.yaml` to an LLM. The LLM maps the changes to
-the agent specializations (listing, graph, chart, map, form, explorer) and generates 3-8
-targeted missions with specific, actionable prompts. Generated mission files follow the same
-YAML format as hand-written ones and can be re-run later with `--missions`.
+the remaining standard and advanced personas and generates 3-8 targeted missions with
+specific, actionable prompts. Generated mission files follow the same YAML format as
+hand-written ones and can be re-run later with `--missions`.
 
 ---
 

--- a/missions/README.md
+++ b/missions/README.md
@@ -18,54 +18,44 @@ missions:
   directory (`report_<thread_id>/`).
 * Reusing the same `thread_id` resumes the prior conversation. Pass `--clear-memory` to
   start fresh.
-* **Routing keywords**: if `thread_id` contains any of `explorer`, `chaos`, or
-  `autonomous`, the mission is dispatched to the **advanced** graph (autonomous
-  exploration). Otherwise it runs on the **standard** 13-agent UI swarm.
+* **Routing keywords**: if `thread_id` contains any of `accessibility`, `a11y`,
+  `data_heavy`, `data-heavy`, `impatient`, `returning`, `explorer`, `chaos`, or
+  `autonomous`, the mission is dispatched to the **advanced** graph. Otherwise it
+  runs on the **standard** 3-persona swarm.
 
 ### `prompt`
 
 * Free-form natural language. The supervisor reads it and decides which specialist agent
   should drive the test.
-* Mention the UI pattern you want exercised (lists, charts, maps, forms, graphs) so the
-  supervisor routes to the right specialist.
+* Mention the user persona or risk area you want exercised so the supervisor routes to the
+  right agent.
 * Use placeholders for app-specific values — for example `<YOUR_APP>`, `<APP_URL>`,
   `<example_search_term>`, `<dashboard_path>` — and replace them before running.
 
-## Standard agents (UI-pattern specialists)
-
-| Agent             | Specialization                                                        |
-|-------------------|-----------------------------------------------------------------------|
-| `listing_agent`   | Lists, tables, search bars, filters, pagination, row detail flyouts   |
-| `graph_agent`     | Node-link graphs, timelines, waterfalls, hierarchical visualizations  |
-| `chart_agent`     | Time-series, bar/line/area charts, KPI tiles, dashboards              |
-| `map_agent`       | Geographic maps, status grids, geospatial overlays                    |
-| `form_agent`      | Forms, wizards, validation, multi-step configuration                  |
-
-## Generic Exploration Personas (Behavioral strategies)
+## Standard agents
 
 | Agent                      | Specialization                                                        |
 |----------------------------|-----------------------------------------------------------------------|
 | `new_user_agent`           | Tests onboarding flows, discoverability, default states, empty states |
-| `power_user_agent`         | Keyboards shortcuts, bulk operations, advanced filters, edge cases    |
+| `power_user_agent`         | Keyboard shortcuts, bulk operations, advanced filters, edge cases     |
 | `adversarial_user_agent`   | Deliberately breaks things (malformed inputs, back-button abuse)      |
-| `impatient_user_agent`     | Rapid interactions, cancels operations, refreshes during load         |
-| `accessibility_user_agent` | Validates WCAG, screen reader nav, keyboard-only interaction          |
-| `constrained_user_agent`   | Tests degraded paths, slow networks, small viewports                  |
-| `data_heavy_user_agent`    | Uploads large files, thousands of records, excessively long strings   |
-| `returning_user_agent`     | Stale sessions, cached pages, outdated bookmarks                      |
 
 ## Advanced agents
 
-| Agent             | Mission                                                               |
-|-------------------|-----------------------------------------------------------------------|
-| `explorer_agent`  | Autonomous chaos exploration; finds crashes, timeouts, regressions    |
+| Agent                      | Specialization                                                        |
+|----------------------------|-----------------------------------------------------------------------|
+| `impatient_user_agent`     | Rapid interactions, cancels operations, refreshes during load         |
+| `accessibility_user_agent` | Validates WCAG, screen reader nav, keyboard-only interaction          |
+| `data_heavy_user_agent`    | Uploads large files, thousands of records, excessively long strings   |
+| `returning_user_agent`     | Stale sessions, cached pages, outdated bookmarks                      |
+| `explorer_agent`           | Autonomous chaos exploration; finds crashes, timeouts, regressions    |
 
 ## Writing a new mission
 
-1. Pick a `thread_id` that signals the area under test (e.g. `smoke_listing_users_01`).
+1. Pick a `thread_id` that signals the persona or area under test (e.g. `smoke_new_user_01`).
 2. Write a prompt that tells the agent **what to do** and **what to verify**, not how.
-3. Reference the UI patterns the supervisor should route to.
-4. If the test should run autonomously without scripted steps, name it with `explorer`,
-   `chaos`, or `autonomous` to dispatch to the advanced graph.
+3. Reference the persona or risk area the supervisor should route to.
+4. If the test should run on an advanced agent, include one of the advanced routing keywords
+   in the `thread_id`; for autonomous exploration, use `explorer`, `chaos`, or `autonomous`.
 
-Each persona has a generic mission template named `<persona>_agent.yaml` in this folder to help you get started.
+Each supported agent has a generic mission template named `<agent>.yaml` in this folder to help you get started.

--- a/missions/README.md
+++ b/missions/README.md
@@ -27,6 +27,9 @@ missions:
 
 * Free-form natural language. The supervisor reads it and decides which specialist agent
   should drive the test.
+* Keep prompts concise and task-oriented. Prefer the smallest context that identifies the
+  page/flow, interactions, and expected verification. Let agents disclose additional MCP,
+  Skill, DOM, and PR context only when needed.
 * Mention the user persona or risk area you want exercised so the supervisor routes to the
   right agent.
 * Use placeholders for app-specific values — for example `<YOUR_APP>`, `<APP_URL>`,
@@ -53,7 +56,7 @@ missions:
 ## Writing a new mission
 
 1. Pick a `thread_id` that signals the persona or area under test (e.g. `smoke_new_user_01`).
-2. Write a prompt that tells the agent **what to do** and **what to verify**, not how.
+2. Write a concise prompt that tells the agent **what to do** and **what to verify**, not how.
 3. Reference the persona or risk area the supervisor should route to.
 4. If the test should run on an advanced agent, include one of the advanced routing keywords
    in the `thread_id`; for autonomous exploration, use `explorer`, `chaos`, or `autonomous`.

--- a/missions/chart_agent.yaml
+++ b/missions/chart_agent.yaml
@@ -1,8 +1,0 @@
-missions:
-- thread_id: test_chart_01
-  prompt: 'Persona: chart_agent
-
-
-    Go to a dashboard view with time-series or bar charts at <APP_URL>. Adjust the
-    time-range picker to <example_time_range>. Validate that tooltips show expected
-    KPIs and data lines render cleanly with analyze_visual_state.'

--- a/missions/constrained_user_agent.yaml
+++ b/missions/constrained_user_agent.yaml
@@ -1,8 +1,0 @@
-missions:
-- thread_id: test_constrained_user_01
-  prompt: 'Persona: constrained_user_agent
-
-
-    Simulate constrained network/viewport conditions at <APP_URL>. Test responsive
-    layout behavior at <mobile_viewport_size>. Verify UI elements don''t overlap,
-    and check how the app handles delayed component loading.'

--- a/missions/form_agent.yaml
+++ b/missions/form_agent.yaml
@@ -1,8 +1,0 @@
-missions:
-- thread_id: test_form_01
-  prompt: 'Persona: form_agent
-
-
-    Navigate to a multi-step wizard or form at <APP_URL>. Submit the form empty to
-    trigger validation errors and verify them. Then fill in correct data, submit,
-    and confirm successful processing via toast or redirect.'

--- a/missions/graph_agent.yaml
+++ b/missions/graph_agent.yaml
@@ -1,8 +1,0 @@
-missions:
-- thread_id: test_graph_01
-  prompt: 'Persona: graph_agent
-
-
-    Load a node-link or timeline graph view in <APP_URL>. Hover over edges and nodes,
-    verifying that tooltips correctly show data and connections. Use analyze_visual_state
-    to confirm correct rendering without overlap.'

--- a/missions/listing_agent.yaml
+++ b/missions/listing_agent.yaml
@@ -1,8 +1,0 @@
-missions:
-- thread_id: test_listing_01
-  prompt: 'Persona: listing_agent
-
-
-    Navigate to the main list view in <APP_URL>. Sort columns, use the search bar,
-    filter by multiple criteria, and assert the results are accurate. Paginate through
-    the list and open item details to ensure context is preserved.'

--- a/missions/map_agent.yaml
+++ b/missions/map_agent.yaml
@@ -1,8 +1,0 @@
-missions:
-- thread_id: test_map_01
-  prompt: 'Persona: map_agent
-
-
-    Find a geographic map or status grid in <APP_URL>. Pan and zoom in/out. Verify
-    cluster expansion behavior and hover on a marker to check its popup for required
-    fields. Validate the visual layout using analyze_visual_state.'

--- a/src/agentic_explorer/main.py
+++ b/src/agentic_explorer/main.py
@@ -50,6 +50,35 @@ ADVANCED_KEYWORDS = (
     "autonomous",
 )
 
+REPORT_TRANSCRIPT_MAX_CHARS = 35_000
+REPORT_TRANSCRIPT_HEAD_CHARS = 6_000
+
+
+def _clip_for_prompt(text: str, max_chars: int) -> str:
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 24:
+        return text[:max(0, max_chars)]
+    return text[: max_chars - 24].rstrip() + " … [truncated]"
+
+
+def _bound_transcript_for_report(transcript: str) -> str:
+    """Keep report context within a predictable prompt budget.
+
+    Reports need the mission start plus the latest outcomes most. Preserve both
+    ends and disclose how much was omitted instead of sending unbounded history.
+    """
+    if len(transcript) <= REPORT_TRANSCRIPT_MAX_CHARS:
+        return transcript
+    tail_chars = REPORT_TRANSCRIPT_MAX_CHARS - REPORT_TRANSCRIPT_HEAD_CHARS - 160
+    omitted = len(transcript) - REPORT_TRANSCRIPT_HEAD_CHARS - tail_chars
+    return (
+        transcript[:REPORT_TRANSCRIPT_HEAD_CHARS].rstrip()
+        + f"\n\n... [omitted {omitted:,} chars of middle transcript for context budget] ...\n\n"
+        + transcript[-tail_chars:].lstrip()
+    )
+
 
 def _get_async_sqlite_saver() -> Any:
     """Import AsyncSqliteSaver while suppressing a known upstream pending warning."""
@@ -390,9 +419,9 @@ async def run_missions():
                 if hasattr(msg, "tool_calls") and msg.tool_calls:
                     text_content += f" [Action: {', '.join(tc['name'] for tc in msg.tool_calls)}]"
                 if text_content.strip():
-                    transcript_lines.append(f"{msg.type.upper()}: {text_content.strip()}")
+                    transcript_lines.append(f"{msg.type.upper()}: {_clip_for_prompt(text_content, 2_000)}")
 
-            clean_transcript = "\n".join(transcript_lines)
+            clean_transcript = _bound_transcript_for_report("\n".join(transcript_lines))
 
             _active_provider = os.getenv("LLM_PROVIDER", "").lower()
             report_model = (

--- a/src/agentic_explorer/main.py
+++ b/src/agentic_explorer/main.py
@@ -17,7 +17,7 @@ warnings.filterwarnings(
 from agentic_explorer.utils import console  # noqa: E402
 
 from langchain_core.messages import (  # noqa: E402
-    HumanMessage, AIMessage, AIMessageChunk, ToolMessage, SystemMessage,
+    HumanMessage, AIMessage, AIMessageChunk, SystemMessage,
 )
 
 from playwright.async_api import async_playwright
@@ -37,8 +37,18 @@ from agentic_explorer.orchestration.advanced_graph import build_advanced_graph
 load_environment()
 
 # Mission-type detection: thread_ids matching these substrings are routed to the
-# advanced (autonomous explorer) graph instead of the standard 5-agent UI swarm.
-ADVANCED_KEYWORDS = ("explorer", "chaos", "autonomous")
+# advanced graph instead of the standard 3-persona swarm.
+ADVANCED_KEYWORDS = (
+    "accessibility",
+    "a11y",
+    "data_heavy",
+    "data-heavy",
+    "impatient",
+    "returning",
+    "explorer",
+    "chaos",
+    "autonomous",
+)
 
 
 def _get_async_sqlite_saver() -> Any:

--- a/src/agentic_explorer/orchestration/advanced_graph.py
+++ b/src/agentic_explorer/orchestration/advanced_graph.py
@@ -1,12 +1,8 @@
-"""Advanced testing graph: autonomous chaos exploration.
+"""Advanced testing graph: deep persona and autonomous chaos exploration.
 
-The advanced graph hosts open-ended exploration agents that don't follow a
-prescriptive script.  The ``explorer_agent`` wanders the app looking for
-crashes, timeouts, and visual regressions.
-
-The single-agent supervisor is preserved as an extension point so additional
-specialized agents (custom fuzzers, integrity auditors, etc.) can be added
-without restructuring the graph.
+The advanced graph hosts high-intensity behavioral personas and the open-ended
+``explorer_agent`` for missions that need focused stress, accessibility,
+statefulness, or autonomous chaos coverage.
 """
 
 from langchain_core.messages import SystemMessage
@@ -36,7 +32,7 @@ from agentic_explorer.orchestration.graph_base import (
 # ---------------------------------------------------------
 
 def build_advanced_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta, max_steps: int = 30, quiet: bool = False):
-    """Build the advanced (autonomous exploration) graph.
+    """Build the advanced persona and autonomous exploration graph.
 
     Args:
         base_tools: MCP, Skills, and raw Playwright tools (browser tools are filtered out).
@@ -50,13 +46,17 @@ def build_advanced_graph(base_tools: list, active_page: Page, checkpointer, app:
     app_url = app.url
     app_name = app.name or "the application"
     app_description = (app.description or "").strip()
+    app_context = (
+        f" The application under test is '{app_name}', accessible at {app_url}."
+        + (f" Domain context: {app_description}" if app_description else "")
+    )
 
     bug_screenshot = get_screenshot_tool(page=active_page)
     execute_browser_command = get_browser_command_tool(page=active_page)
     get_dom_snapshot = get_dom_snapshot_tool(page=active_page)
     generate_reproduction_spec = get_code_generator_tool(app_url=app_url)
 
-    explorer_tools = filter_base_tools(base_tools) + [
+    advanced_tools = filter_base_tools(base_tools) + [
         execute_browser_command,
         get_dom_snapshot,
         bug_screenshot,
@@ -64,6 +64,69 @@ def build_advanced_graph(base_tools: list, active_page: Page, checkpointer, app:
     ]
 
     domain_line = f"Domain context: {app_description}\n\n" if app_description else ""
+
+    global_qa_rule = (
+        " ARCHITECTURE — RECORD & TRANSLATE: You are the *brain*. You do NOT touch the browser directly."
+        " To interact with the application you MUST emit strict JSON commands to 'execute_browser_command'."
+        " Use 'get_dom_snapshot' to inspect the page before choosing a selector."
+        " Use 'check_page_health' (action: 'check_page_health') to detect spinners and error banners."
+        " Every command is appended to an immutable Action Tape. Supported actions:"
+        " navigate, click, fill, press, select_option, hover, wait_for, scroll, extract_text,"
+        " snapshot, check_page_health."
+        " Example: execute_browser_command({\"action\":\"click\",\"selector\":\"[data-test-subj='submitButton']\"})."
+        " BEFORE planning, if MCP documentation tools or installed Skills are available,"
+        " consult them to look up expected behaviors for the area under test. Do not guess."
+        " IMPORTANT: If you discover any UI error, missing element, tool failure, or visual anomaly,"
+        " you MUST (1) invoke 'capture_bug_screenshot' to save visual evidence, then"
+        " (2) invoke 'generate_reproduction_spec' so the Action Tape is translated into a"
+        " runnable Playwright .spec.ts that the developer can execute locally."
+        " ——— SELECTOR POLICY (STRICTLY ENFORCED) ———"
+        " You MUST use ONLY resilient, stable selectors. Priority order:"
+        " 1. data-test-subj attributes   → [data-test-subj='myButton']"
+        " 2. ARIA labels / roles         → [aria-label='Search'], role='dialog'"
+        " 3. Semantic HTML / visible text → button:has-text('Save'), text='Apply'"
+        " FORBIDDEN: XPath expressions (//div, /html/body/div[2]/span), positional CSS like"
+        " 'div:nth-child(3) > span'. Call get_dom_snapshot first and look for data-test-subj"
+        " or aria-label. NEVER invent a selector — brittle selectors cause flaky scripts."
+    )
+
+    accessibility_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
+        "You are the Accessibility User Persona."
+        + app_context +
+        " You test screen reader navigation, keyboard-only interaction, high-contrast/zoom modes, "
+        "focus order, semantic structure, labels, and inclusive design. Validate WCAG-oriented behaviors "
+        "without relying on implementation assumptions. Drive the UI exclusively through "
+        "'execute_browser_command' JSON intents."
+        + global_qa_rule
+    )))
+
+    data_heavy_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
+        "You are the Data-Heavy User Persona."
+        + app_context +
+        " You upload large files, create many records, use very long strings, deeply nested structures, "
+        "large result sets, and boundary-sized inputs. Expose performance cliffs, pagination bugs, "
+        "timeouts, and degraded states. Drive the UI exclusively through 'execute_browser_command' JSON intents."
+        + global_qa_rule
+    )))
+
+    impatient_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
+        "You are the Impatient User Persona."
+        + app_context +
+        " You cancel operations mid-flight, refresh during submissions, click buttons multiple times, "
+        "navigate away during async processes, and rapidly change filters or inputs. Expose race conditions, "
+        "duplicate submissions, and incomplete state handling. Drive the UI exclusively through "
+        "'execute_browser_command' JSON intents."
+        + global_qa_rule
+    )))
+
+    returning_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
+        "You are the Returning User Persona."
+        + app_context +
+        " You simulate stale sessions, cached pages, outdated bookmarks, saved credentials, expired tokens, "
+        "and user journeys resumed after time away. Test upgrade paths, session expiry, redirect behavior, "
+        "and backward compatibility. Drive the UI exclusively through 'execute_browser_command' JSON intents."
+        + global_qa_rule
+    )))
 
     explorer_prompt = SystemMessage(content=f"""You are the Autonomous Explorer Agent — an engineer chasing an unreproducible incident.
 
@@ -113,7 +176,7 @@ EXPLORATION STRATEGY
    b. Extract the exact error text from the DOM via `extract_text`.
    c. Record the reproduction steps and call `generate_reproduction_spec`.
 
-5. Continue for 10–15 different interaction paths before concluding.
+5. Continue for 30–40 different interaction paths before concluding.
    Vary the entry point each cycle — listing views, form flows, detail pages,
    settings panels, and any navigation item visible in `get_dom_snapshot`.
 
@@ -123,14 +186,26 @@ IMPORTANT
 - Your goal is to find the breaking points the development team missed.
 """)
 
-    explorer_agent = create_agent(llm, tools=explorer_tools, system_prompt=explorer_prompt)
+    explorer_agent = create_agent(llm, tools=advanced_tools, system_prompt=explorer_prompt)
 
     agent_registry = {
+        "accessibility_user_agent": accessibility_user_agent,
+        "data_heavy_user_agent": data_heavy_user_agent,
+        "impatient_user_agent": impatient_user_agent,
+        "returning_user_agent": returning_user_agent,
         "explorer_agent": explorer_agent,
     }
 
+    agent_descriptions = """
+- accessibility_user_agent: Validates WCAG-oriented behavior, screen reader navigation, focus order, and keyboard-only interaction.
+- data_heavy_user_agent: Stresses large files, large record sets, long strings, and performance-sensitive workflows.
+- impatient_user_agent: Cancels operations, refreshes mid-flight, clicks repeatedly, and exposes race conditions.
+- returning_user_agent: Tests stale sessions, cached pages, outdated bookmarks, and resumed user journeys.
+- explorer_agent: Autonomous chaos exploration across features, integrations, edge cases, and regression sweeps.
+"""
+
     workflow = StateGraph(AgentState)  # type: ignore[arg-type]
-    workflow.add_node("Supervisor", make_supervisor_node(llm, tuple(agent_registry), app_url, max_steps))  # type: ignore[arg-type]
+    workflow.add_node("Supervisor", make_supervisor_node(llm, tuple(agent_registry), app_url, max_steps, agent_descriptions))  # type: ignore[arg-type]
     for agent_name, agent in agent_registry.items():
         workflow.add_node(agent_name, make_agent_node(agent, name=agent_name, quiet=quiet))  # type: ignore[arg-type]
 

--- a/src/agentic_explorer/orchestration/advanced_graph.py
+++ b/src/agentic_explorer/orchestration/advanced_graph.py
@@ -24,6 +24,8 @@ from agentic_explorer.orchestration.graph_base import (
     make_supervisor_node,
     make_llm,
     compile_swarm,
+    make_browser_agent_prompt,
+    BROWSER_AGENT_RULES,
 )
 
 
@@ -65,126 +67,38 @@ def build_advanced_graph(base_tools: list, active_page: Page, checkpointer, app:
 
     domain_line = f"Domain context: {app_description}\n\n" if app_description else ""
 
-    global_qa_rule = (
-        " ARCHITECTURE — RECORD & TRANSLATE: You are the *brain*. You do NOT touch the browser directly."
-        " To interact with the application you MUST emit strict JSON commands to 'execute_browser_command'."
-        " Use 'get_dom_snapshot' to inspect the page before choosing a selector."
-        " Use 'check_page_health' (action: 'check_page_health') to detect spinners and error banners."
-        " Every command is appended to an immutable Action Tape. Supported actions:"
-        " navigate, click, fill, press, select_option, hover, wait_for, scroll, extract_text,"
-        " snapshot, check_page_health."
-        " Example: execute_browser_command({\"action\":\"click\",\"selector\":\"[data-test-subj='submitButton']\"})."
-        " BEFORE planning, if MCP documentation tools or installed Skills are available,"
-        " consult them to look up expected behaviors for the area under test. Do not guess."
-        " IMPORTANT: If you discover any UI error, missing element, tool failure, or visual anomaly,"
-        " you MUST (1) invoke 'capture_bug_screenshot' to save visual evidence, then"
-        " (2) invoke 'generate_reproduction_spec' so the Action Tape is translated into a"
-        " runnable Playwright .spec.ts that the developer can execute locally."
-        " ——— SELECTOR POLICY (STRICTLY ENFORCED) ———"
-        " You MUST use ONLY resilient, stable selectors. Priority order:"
-        " 1. data-test-subj attributes   → [data-test-subj='myButton']"
-        " 2. ARIA labels / roles         → [aria-label='Search'], role='dialog'"
-        " 3. Semantic HTML / visible text → button:has-text('Save'), text='Apply'"
-        " FORBIDDEN: XPath expressions (//div, /html/body/div[2]/span), positional CSS like"
-        " 'div:nth-child(3) > span'. Call get_dom_snapshot first and look for data-test-subj"
-        " or aria-label. NEVER invent a selector — brittle selectors cause flaky scripts."
-    )
-
-    accessibility_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
-        "You are the Accessibility User Persona."
-        + app_context +
-        " You test screen reader navigation, keyboard-only interaction, high-contrast/zoom modes, "
-        "focus order, semantic structure, labels, and inclusive design. Validate WCAG-oriented behaviors "
-        "without relying on implementation assumptions. Drive the UI exclusively through "
-        "'execute_browser_command' JSON intents."
-        + global_qa_rule
+    accessibility_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the Accessibility User Persona",
+        app_context,
+        "Test keyboard-only navigation, focus order, semantic structure, labels, high-contrast/zoom behavior, and WCAG-oriented outcomes.",
     )))
 
-    data_heavy_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
-        "You are the Data-Heavy User Persona."
-        + app_context +
-        " You upload large files, create many records, use very long strings, deeply nested structures, "
-        "large result sets, and boundary-sized inputs. Expose performance cliffs, pagination bugs, "
-        "timeouts, and degraded states. Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
+    data_heavy_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the Data-Heavy User Persona",
+        app_context,
+        "Use large files, many records, long strings, nested data, large result sets, and boundary inputs to expose performance cliffs and pagination bugs.",
     )))
 
-    impatient_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
-        "You are the Impatient User Persona."
-        + app_context +
-        " You cancel operations mid-flight, refresh during submissions, click buttons multiple times, "
-        "navigate away during async processes, and rapidly change filters or inputs. Expose race conditions, "
-        "duplicate submissions, and incomplete state handling. Drive the UI exclusively through "
-        "'execute_browser_command' JSON intents."
-        + global_qa_rule
+    impatient_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the Impatient User Persona",
+        app_context,
+        "Cancel mid-flight, refresh during submissions, click repeatedly, navigate away during async work, and rapidly change filters to expose races.",
     )))
 
-    returning_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=(
-        "You are the Returning User Persona."
-        + app_context +
-        " You simulate stale sessions, cached pages, outdated bookmarks, saved credentials, expired tokens, "
-        "and user journeys resumed after time away. Test upgrade paths, session expiry, redirect behavior, "
-        "and backward compatibility. Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
+    returning_user_agent = create_agent(llm, tools=advanced_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the Returning User Persona",
+        app_context,
+        "Simulate stale sessions, cached pages, outdated bookmarks, expired tokens, and journeys resumed after time away.",
     )))
 
-    explorer_prompt = SystemMessage(content=f"""You are the Autonomous Explorer Agent — an engineer chasing an unreproducible incident.
-
-Application under test: '{app_name}' at {app_url}
-{domain_line}RECORD-AND-TRANSLATE ARCHITECTURE
-You are the brain. You do NOT touch the browser directly. Drive the UI by emitting
-strict JSON commands to `execute_browser_command`:
-
-  execute_browser_command({{"action":"navigate","url":"{app_url}"}})
-  execute_browser_command({{"action":"click","selector":"[data-test-subj='submitButton']"}})
-  execute_browser_command({{"action":"fill","selector":"input[aria-label='Search']","value":"hello"}})
-  execute_browser_command({{"action":"check_page_health"}})
-
-Allowed actions: navigate, click, fill, press, select_option, hover, wait_for,
-scroll, extract_text, snapshot, check_page_health.
-
-Use `get_dom_snapshot` to *see* the page before choosing selectors. Every command
-is appended to an immutable Action Tape translatable to a Playwright `.spec.ts`.
-
-SELECTOR POLICY (STRICTLY ENFORCED)
-Priority order:
-  1. [data-test-subj='myButton']
-  2. [aria-label='Search'], role=button[name='Submit']
-  3. button:has-text('Save'), text='Apply'
-FORBIDDEN: XPath (//div, /html/...), :nth-child, :nth-of-type, bare positional paths.
-Call `get_dom_snapshot` first — NEVER guess or construct structural paths.
-
-EXPLORATION STRATEGY
-1. Navigate to {app_url}, call `get_dom_snapshot` to discover all entry points.
-
-2. Perform *chaotic* interactions across as many distinct areas as possible:
-   - Click filters, dropdowns, and toggles in unusual or rapid sequences.
-   - Combine multiple filters simultaneously (time range + category + search term).
-   - Expand multiple panels, columns, or detail views at the same time.
-   - Navigate between cross-linked pages and verify context is preserved.
-   - Scroll to the bottom of long lists and paginated views.
-   - Submit forms with boundary-value inputs (empty string, very long text,
-     special characters: <script>, '; DROP TABLE, unicode emoji 🔥).
-
-3. After each significant interaction, call `check_page_health` to detect:
-   - Active loading spinners (stuck > 30 s indicates a hang).
-   - Inline error banners ("Request failed", "Timeout", "Server error", HTTP 5xx).
-   - Blank or white screens after navigation.
-
-4. On ANY error signal:
-   a. Call `capture_bug_screenshot` IMMEDIATELY with a descriptive bug_summary.
-   b. Extract the exact error text from the DOM via `extract_text`.
-   c. Record the reproduction steps and call `generate_reproduction_spec`.
-
-5. Continue for 30–40 different interaction paths before concluding.
-   Vary the entry point each cycle — listing views, form flows, detail pages,
-   settings panels, and any navigation item visible in `get_dom_snapshot`.
-
-IMPORTANT
-- Be genuinely random and unpredictable — avoid repetitive patterns.
-- Test boundary cases: extreme values, many simultaneous filters, rapid clicks.
-- Your goal is to find the breaking points the development team missed.
-""")
+    explorer_prompt = SystemMessage(content=(
+        "You are the Autonomous Explorer Agent chasing unreproducible incidents. "
+        f"Application: '{app_name}' at {app_url}. {domain_line}"
+        "Explore chaotically across distinct areas: filters, dropdowns, toggles, cross-links, "
+        "long lists, forms, settings, boundary inputs, rapid clicks, refreshes, and combined filters. "
+        "After significant interactions call check_page_health. Vary entry points and avoid repetitive paths. "
+        + BROWSER_AGENT_RULES
+    ))
 
     explorer_agent = create_agent(llm, tools=advanced_tools, system_prompt=explorer_prompt)
 

--- a/src/agentic_explorer/orchestration/graph_base.py
+++ b/src/agentic_explorer/orchestration/graph_base.py
@@ -21,6 +21,24 @@ from agentic_explorer.utils import console
 from agentic_explorer.utils.llm import make_llm  # noqa: F401  re-exported for back-compat
 
 
+BROWSER_AGENT_RULES = (
+    " Context policy: use progressive disclosure. Start with mission + current DOM; "
+    "call MCP/Skill tools only for the specific feature under test, and request details "
+    "only when needed. Browser policy: you are the brain, not the hands. Interact only "
+    "through execute_browser_command JSON intents after get_dom_snapshot. Allowed actions: "
+    "navigate, click, fill, press, select_option, hover, wait_for, scroll, extract_text, "
+    "snapshot, check_page_health. Selector policy: prefer data-test-subj, then ARIA/roles, "
+    "then semantic text; never use XPath, nth-child/nth-of-type, or guessed structural CSS. "
+    "Failure policy: on any UI error, missing element, tool failure, or visual anomaly, call "
+    "capture_bug_screenshot, then generate_reproduction_spec immediately."
+)
+
+
+def make_browser_agent_prompt(role: str, app_context: str, focus: str) -> str:
+    """Build a compact system prompt for browser-driving QA agents."""
+    return f"You are {role}.{app_context} {focus} {BROWSER_AGENT_RULES}"
+
+
 # ---------------------------------------------------------
 # Shared state schema
 # ---------------------------------------------------------
@@ -93,6 +111,85 @@ def _msg_text(msg: BaseMessage) -> str:
     if isinstance(content, list):
         return "".join(b.get("text", "") for b in content if isinstance(b, dict) and "text" in b)
     return str(content)
+
+
+def _clip_text(text: str, max_chars: int) -> str:
+    """Return ``text`` capped for LLM routing/report prompts."""
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 24:
+        return text[:max(0, max_chars)]
+    return text[: max_chars - 24].rstrip() + " … [truncated]"
+
+
+def _compact_message(msg: BaseMessage, max_chars: int = 900) -> str:
+    """Summarize one LangChain message for supervisor routing.
+
+    The supervisor only needs enough context to pick the next worker. Passing the
+    complete historical transcript on every turn can exhaust context on long
+    missions, so this keeps recent intent, tool names, and tool outcomes only.
+    """
+    if isinstance(msg, SystemMessage):
+        return ""
+    role = msg.type.upper()
+    text = _clip_text(_msg_text(msg), max_chars)
+    tool_calls = getattr(msg, "tool_calls", None) or []
+    if tool_calls:
+        tools = ", ".join(tc.get("name", "unknown_tool") for tc in tool_calls)
+        text = f"{text} [tool_calls: {tools}]" if text else f"[tool_calls: {tools}]"
+    if isinstance(msg, ToolMessage):
+        tool_name = getattr(msg, "name", "tool") or "tool"
+        role = f"TOOL:{tool_name}"
+    return f"{role}: {text}" if text else ""
+
+
+def _first_human_message(messages: Sequence[BaseMessage]) -> str:
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            return _clip_text(_msg_text(msg), 1800)
+    return "<mission prompt unavailable>"
+
+
+def _format_recent_progress(messages: Sequence[BaseMessage], *, limit: int = 12) -> str:
+    compact = [line for msg in messages if (line := _compact_message(msg))]
+    recent = compact[-limit:]
+    if not recent:
+        return "- No agent progress yet."
+    return "\n".join(f"- {line}" for line in recent)
+
+
+def _format_recent_actions(actions: Sequence[Dict[str, Any]], *, limit: int = 10) -> str:
+    recent = list(actions)[-limit:]
+    if not recent:
+        return "- No browser actions recorded yet."
+    lines = []
+    for entry in recent:
+        action = entry.get("action", "unknown")
+        ok = "ok" if entry.get("ok") else "error"
+        params = entry.get("params") or {}
+        selector = params.get("selector") or params.get("url") or params.get("key") or ""
+        lines.append(f"- {action}({selector}) -> {ok}")
+    return "\n".join(lines)
+
+
+def _build_routing_context(state: AgentState, extra_messages: Sequence[BaseMessage]) -> str:
+    """Build a bounded routing brief for the supervisor LLM."""
+    messages = list(state.get("messages", []))
+    bugs = list(state.get("bugs_found", []))
+    paths = list(dict.fromkeys(state.get("explored_paths", [])))[:8]
+    reset_lines = [line for msg in extra_messages if (line := _compact_message(msg, max_chars=700))]
+
+    sections = [
+        "MISSION:\n" + _first_human_message(messages),
+        "RECENT_PROGRESS:\n" + _format_recent_progress(messages),
+        "RECENT_BROWSER_ACTIONS:\n" + _format_recent_actions(state.get("action_tape", [])),
+        "BUGS_FOUND:\n" + ("\n".join(f"- {_clip_text(b, 240)}" for b in bugs[-8:]) if bugs else "- none"),
+        "EXPLORED_URLS:\n" + ("\n".join(f"- {p}" for p in paths) if paths else "- none"),
+    ]
+    if reset_lines:
+        sections.append("RESET_DIRECTIVE:\n" + "\n".join(f"- {line}" for line in reset_lines))
+    return "\n\n".join(sections)
 
 
 def _summarize_tool_args(tool_call: dict, max_chars: int = 80) -> str:
@@ -230,10 +327,14 @@ def make_supervisor_node(llm, agent_names: tuple, app_url: str, max_steps: int, 
             "and sufficient areas have been covered."
         )
 
-        messages_for_routing = list(state["messages"]) + extra_messages
-        routing_request = HumanMessage(content="Based on the progress above, which agent should act next?")
+        routing_context = _build_routing_context(state, extra_messages)
+        routing_request = HumanMessage(content=(
+            "Use this compact mission context to choose the next agent. Do not request "
+            "full history unless necessary; route based on current objective, recent "
+            f"progress, and coverage gaps.\n\n{routing_context}\n\nWhich agent should act next?"
+        ))
         decision = await routing_llm.ainvoke(
-            [SystemMessage(content=supervisor_prompt), *messages_for_routing, routing_request]
+            [SystemMessage(content=supervisor_prompt), routing_request]
         )
 
         result: dict = {"next_agent": decision["next"], "step_count": current_step}

--- a/src/agentic_explorer/orchestration/standard_graph.py
+++ b/src/agentic_explorer/orchestration/standard_graph.py
@@ -17,6 +17,7 @@ from agentic_explorer.orchestration.graph_base import (
     make_supervisor_node,
     make_llm,
     compile_swarm,
+    make_browser_agent_prompt,
 )
 
 # ---------------------------------------------------------
@@ -58,56 +59,22 @@ def build_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta,
         bug_screenshot,
         generate_reproduction_spec,
     ]
-    global_qa_rule = (
-        " ARCHITECTURE — RECORD & TRANSLATE: You are the *brain*. You do NOT touch the browser directly."
-        " To interact with the application you MUST emit strict JSON commands to 'execute_browser_command'."
-        " Use 'get_dom_snapshot' to inspect the page before choosing a selector."
-        " Use 'check_page_health' (action: 'check_page_health') to detect spinners and error banners."
-        " Every command is appended to an immutable Action Tape. Supported actions:"
-        " navigate, click, fill, press, select_option, hover, wait_for, scroll, extract_text,"
-        " snapshot, check_page_health."
-        " Example: execute_browser_command({\"action\":\"click\",\"selector\":\"[data-test-subj='submitButton']\"})."
-        " BEFORE planning, if MCP documentation tools or installed Skills are available,"
-        " consult them to look up expected behaviors for the area under test. Do not guess."
-        " IMPORTANT: If you discover any UI error, missing element, tool failure, or visual anomaly,"
-        " you MUST (1) invoke 'capture_bug_screenshot' to save visual evidence, then"
-        " (2) invoke 'generate_reproduction_spec' so the Action Tape is translated into a"
-        " runnable Playwright .spec.ts that the developer can execute locally."
-        " ——— SELECTOR POLICY (STRICTLY ENFORCED) ———"
-        " You MUST use ONLY resilient, stable selectors. Priority order:"
-        " 1. data-test-subj attributes   → [data-test-subj='myButton']"
-        " 2. ARIA labels / roles         → [aria-label='Search'], role='dialog'"
-        " 3. Semantic HTML / visible text → button:has-text('Save'), text='Apply'"
-        " FORBIDDEN: XPath expressions (//div, /html/body/div[2]/span), positional CSS like"
-        " 'div:nth-child(3) > span'. Call get_dom_snapshot first and look for data-test-subj"
-        " or aria-label. NEVER invent a selector — brittle selectors cause flaky scripts."
-    )
-
-    new_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the New User / First-Timer Persona."
-        + app_context +
-        " You know nothing about the app. Test onboarding flows, discoverability, default states, and empty states. "
-        "Catch assumptions developers make about prior knowledge. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
+    new_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the New User / First-Timer Persona",
+        app_context,
+        "Test onboarding, discoverability, default states, and empty states. Catch assumptions about prior knowledge.",
     )))
 
-    power_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Power User Persona."
-        + app_context +
-        " You use keyboard shortcuts, bulk operations, advanced filters, edge-case workflows. "
-        "Push features to their limits and chain operations in unexpected ways. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
+    power_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the Power User Persona",
+        app_context,
+        "Use keyboard shortcuts, bulk operations, advanced filters, and edge workflows; chain operations in unexpected ways.",
     )))
 
-    adversarial_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Adversarial User (Chaos Monkey) Persona."
-        + app_context +
-        " You deliberately try to break things — invalid inputs, SQL injection attempts, rapid clicks, back-button abuse, "
-        "concurrent sessions, boundary values. Focused on robustness and security. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
+    adversarial_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=make_browser_agent_prompt(
+        "the Adversarial User (Chaos Monkey) Persona",
+        app_context,
+        "Try to break flows with invalid inputs, injection-like strings, rapid clicks, back-button abuse, concurrent sessions, and boundary values.",
     )))
 
     agent_registry = {

--- a/src/agentic_explorer/orchestration/standard_graph.py
+++ b/src/agentic_explorer/orchestration/standard_graph.py
@@ -4,7 +4,7 @@ from langchain.agents import create_agent
 from playwright.async_api import Page
 
 from agentic_explorer.config import AppMeta
-from agentic_explorer.tools.common.custom_tools import get_visual_validation_tool, get_screenshot_tool
+from agentic_explorer.tools.common.custom_tools import get_screenshot_tool
 from agentic_explorer.tools.browser.engine import (
     get_browser_command_tool,
     get_dom_snapshot_tool,
@@ -24,7 +24,7 @@ from agentic_explorer.orchestration.graph_base import (
 # ---------------------------------------------------------
 
 def build_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta, max_steps: int = 30, quiet: bool = False):
-    """Build the standard QA swarm of 5 UI-pattern specialist agents.
+    """Build the standard QA swarm of three behavioral persona agents.
 
     Args:
         base_tools: MCP, Skills, and raw Playwright tools (browser tools are filtered out).
@@ -44,7 +44,6 @@ def build_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta,
     )
 
     # Initialize page-aware tools
-    vision_validation = get_visual_validation_tool(page=active_page)
     bug_screenshot = get_screenshot_tool(page=active_page)
     execute_browser_command = get_browser_command_tool(page=active_page)
     get_dom_snapshot = get_dom_snapshot_tool(page=active_page)
@@ -59,8 +58,6 @@ def build_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta,
         bug_screenshot,
         generate_reproduction_spec,
     ]
-    visual_tools = dom_tools + [vision_validation]
-
     global_qa_rule = (
         " ARCHITECTURE — RECORD & TRANSLATE: You are the *brain*. You do NOT touch the browser directly."
         " To interact with the application you MUST emit strict JSON commands to 'execute_browser_command'."
@@ -85,57 +82,6 @@ def build_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta,
         " 'div:nth-child(3) > span'. Call get_dom_snapshot first and look for data-test-subj"
         " or aria-label. NEVER invent a selector — brittle selectors cause flaky scripts."
     )
-
-    listing_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Listing & Search QA Specialist."
-        + app_context +
-        " Your focus is list views, data tables, search/filter bars, faceted navigation, "
-        "infinite scroll, pagination, and row-detail flyouts/expanders. "
-        "Verify result counts, sort behavior, search highlighting, empty states, and that "
-        "row interactions (clicks, expanders, context menus) reveal correctly populated detail panels. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
-    )))
-
-    graph_agent = create_agent(llm, tools=visual_tools, system_prompt=SystemMessage(content=(
-        "You are the Graph & Timeline QA Specialist."
-        + app_context +
-        " Your focus is node-link graphs, hierarchical trees, waterfalls, timelines, and any complex "
-        "SVG/Canvas visualization where rendering correctness matters as much as data correctness. "
-        "You MUST invoke 'analyze_visual_state' to validate that nodes, edges, lanes, and connectors "
-        "render without overlap, broken segments, or layout regressions."
-        + global_qa_rule
-    )))
-
-    chart_agent = create_agent(llm, tools=visual_tools, system_prompt=SystemMessage(content=(
-        "You are the Chart & Dashboard QA Specialist."
-        + app_context +
-        " Your focus is time-series charts, bar/line/area visualizations, KPI tiles, gauge widgets, "
-        "and dashboards composed of multiple panels. Exercise time-range pickers, legend toggles, "
-        "tooltips, drill-downs, and panel resizing. Use 'analyze_visual_state' to verify axis labels, "
-        "data lines, and tile layouts render cleanly."
-        + global_qa_rule
-    )))
-
-    map_agent = create_agent(llm, tools=visual_tools, system_prompt=SystemMessage(content=(
-        "You are the Map & Status-Grid QA Specialist."
-        + app_context +
-        " Your focus is geographic maps, geospatial overlays, status grids/heatmaps, and any "
-        "spatially-arranged visualization. Validate marker placement, cluster collapsing, panning/zooming, "
-        "tooltip popups, and that grids render without overlapping or missing tiles. "
-        "Use 'analyze_visual_state' to verify spatial correctness."
-        + global_qa_rule
-    )))
-
-    form_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Form & Wizard QA Specialist."
-        + app_context +
-        " Your focus is forms, multi-step wizards, configuration screens, and validation flows. "
-        "Exercise required-field validation, format constraints, slider/numeric inputs, dependent "
-        "field reveals, and submission outcomes (success toasts, inline errors, redirect targets). "
-        "Interact only by emitting JSON intents to 'execute_browser_command'."
-        + global_qa_rule
-    )))
 
     new_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
         "You are the New User / First-Timer Persona."
@@ -164,81 +110,16 @@ def build_graph(base_tools: list, active_page: Page, checkpointer, app: AppMeta,
         + global_qa_rule
     )))
 
-    impatient_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Impatient User Persona."
-        + app_context +
-        " You cancel operations mid-flight, refresh during submissions, click buttons multiple times, navigate away during async processes. "
-        "Expose race conditions and incomplete state handling. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
-    )))
-
-    accessibility_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Accessibility User Persona."
-        + app_context +
-        " You test for Screen reader navigation, keyboard-only interaction, high-contrast/zoom modes. "
-        "Validate WCAG compliance and inclusive design. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
-    )))
-
-    constrained_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Mobile / Constrained User Persona."
-        + app_context +
-        " You simulate slow network, small viewport, intermittent connectivity, low storage. "
-        "Test degraded-experience paths and responsive design. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
-    )))
-
-    data_heavy_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Data-Heavy User Persona."
-        + app_context +
-        " You upload large files, create thousands of records, use long strings, deeply nested structures. "
-        "Expose performance cliffs and pagination bugs. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
-    )))
-
-    returning_user_agent = create_agent(llm, tools=dom_tools, system_prompt=SystemMessage(content=(
-        "You are the Returning User Persona."
-        + app_context +
-        " You simulate having stale sessions, cached pages, outdated bookmarks, saved credentials. "
-        "Test upgrade paths, session expiry, and backward compatibility. "
-        "Drive the UI exclusively through 'execute_browser_command' JSON intents."
-        + global_qa_rule
-    )))
-
     agent_registry = {
-        "listing_agent": listing_agent,
-        "graph_agent": graph_agent,
-        "chart_agent": chart_agent,
-        "map_agent": map_agent,
-        "form_agent": form_agent,
         "new_user_agent": new_user_agent,
         "power_user_agent": power_user_agent,
         "adversarial_user_agent": adversarial_user_agent,
-        "impatient_user_agent": impatient_user_agent,
-        "accessibility_user_agent": accessibility_user_agent,
-        "constrained_user_agent": constrained_user_agent,
-        "data_heavy_user_agent": data_heavy_user_agent,
-        "returning_user_agent": returning_user_agent,
     }
 
     agent_descriptions = """
-- listing_agent: List views, search/filter, pagination, data tables, row details, flyouts
-- graph_agent: Node-link graphs, timelines, tree visualizations, SVG/Canvas renders
-- chart_agent: Charts, dashboards, KPI tiles, time-range pickers, gauge widgets
-- map_agent: Geographic maps, status grids, spatial overlays, marker clusters
-- form_agent: Forms, multi-step wizards, validation flows, configuration screens, input fields
 - new_user_agent: Tests onboarding flows, discoverability, default states, and empty states.
 - power_user_agent: Uses keyboard shortcuts, bulk operations, advanced filters, edge-case workflows.
 - adversarial_user_agent: Deliberately tries to break things — invalid inputs, SQL injection attempts, rapid clicks, back-button abuse.
-- impatient_user_agent: Cancels operations mid-flight, refreshes during submissions, clicks buttons multiple times.
-- accessibility_user_agent: Validates WCAG compliance, screen reader navigation, keyboard-only interaction.
-- constrained_user_agent: Tests degraded-experience paths and responsive design for slow networks and small viewports.
-- data_heavy_user_agent: Uploads large files, creates thousands of records, uses long strings.
-- returning_user_agent: Scenarios for returning users with stale sessions, cached pages, outdated bookmarks.
 """
 
     workflow = StateGraph(AgentState)  # type: ignore[arg-type]

--- a/src/agentic_explorer/pr_analyzer.py
+++ b/src/agentic_explorer/pr_analyzer.py
@@ -36,6 +36,33 @@ _PR_URL_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)")
 
 MAX_DIFF_CHARS = 100_000
 
+_ALLOWED_PR_AGENT_KEYWORDS = (
+    "new_user",
+    "power_user",
+    "adversarial_user",
+    "accessibility_user",
+    "accessibility",
+    "a11y",
+    "data_heavy_user",
+    "data_heavy",
+    "data-heavy",
+    "impatient_user",
+    "impatient",
+    "returning_user",
+    "returning",
+    "explorer",
+    "chaos",
+    "autonomous",
+)
+_DELETED_PR_AGENT_KEYWORDS = (
+    "listing",
+    "graph",
+    "chart",
+    "map",
+    "form",
+    "constrained",
+)
+
 
 @dataclass
 class PRData:
@@ -338,23 +365,18 @@ _SYSTEM_PROMPT = """\
 You are a QA Test Architect. You analyze code changes in pull requests and generate \
 targeted test missions for an autonomous testing framework.
 
-The framework has 6 agent types, each specializing in specific UI patterns:
-- listing_agent: List views, search/filter, pagination, data tables, row details, flyouts
-- graph_agent: Node-link graphs, timelines, tree visualizations, SVG/Canvas renders
-- chart_agent: Charts, dashboards, KPI tiles, time-range pickers, gauge widgets
-- map_agent: Geographic maps, status grids, spatial overlays, marker clusters
-- form_agent: Forms, multi-step wizards, validation flows, configuration screens, input fields
-- explorer_agent (autonomous): Open-ended chaos testing, cross-feature integration, edge cases, regression sweeps (use thread_id containing "explorer" or "autonomous")
-
-In addition, it has 8 generic exploration personas that you can route to:
+The framework has 3 standard exploration personas:
 - new_user_agent: Tests onboarding flows, discoverability, default states, and empty states. Catches assumptions developers make about prior knowledge.
 - power_user_agent: Uses keyboard shortcuts, bulk operations, advanced filters, edge-case workflows. Pushes features to their limits.
 - adversarial_user_agent: Deliberately tries to break things — invalid inputs, SQL injection attempts, rapid clicks, back-button abuse.
+
+It also has 5 advanced agents for deeper coverage:
 - impatient_user_agent: Cancels operations mid-flight, refreshes during submissions, clicks buttons multiple times.
 - accessibility_user_agent: Validates WCAG compliance, screen reader navigation, keyboard-only interaction, high-contrast/zoom modes.
-- constrained_user_agent: Tests degraded-experience paths and responsive design for slow networks and small viewports.
 - data_heavy_user_agent: Uploads large files, creates thousands of records, uses long strings. Exposes performance cliffs.
 - returning_user_agent: Scenarios for returning users with stale sessions, cached pages, outdated bookmarks.
+- explorer_agent (autonomous): Open-ended chaos testing, cross-feature integration, edge cases, regression sweeps.
+
 
 Each mission has:
   - thread_id: A unique identifier namespaced to this PR (format: pr_{number}_{agent_type}_{nn})
@@ -363,17 +385,17 @@ Each mission has:
 Output FORMAT (raw YAML, no code fences):
 
 missions:
-  - thread_id: "pr_123_listing_01"
+  - thread_id: "pr_123_new_user_01"
     prompt: >
       Navigate to ... verify ... interact with ...
 
 Rules:
 1. Generate 3-8 missions depending on the scope of changes.
 2. Each prompt MUST be specific and actionable, referencing concrete UI areas/flows.
-3. Map code changes to the MOST relevant agent type based on what UI pattern is affected.
+3. Map code changes to the MOST relevant remaining agent persona based on the user behavior or risk being tested.
 4. Include at least one explorer/autonomous mission for broad regression coverage.
 5. Thread IDs MUST follow the pattern: pr_{number}_{agenttype}_{nn}
-6. Use "explorer" or "autonomous" in thread_id for chaos-exploration missions.
+6. Use "accessibility", "data_heavy", "impatient", "returning", "explorer", "chaos", or "autonomous" in thread_id for advanced missions.
 7. Prompts should reference the specific features/areas that the code changes touch.
 8. Do NOT use placeholder values — use the actual app name and URL provided.
 9. Each prompt should tell the agent what page to navigate to, what to interact with, \
@@ -416,6 +438,12 @@ def _validate_missions(data: Any, pr_number: int) -> dict:
             raise ValueError(f"Mission {i} missing 'thread_id' or 'prompt'")
         if not isinstance(m["thread_id"], str) or not isinstance(m["prompt"], str):
             raise ValueError(f"Mission {i} 'thread_id' and 'prompt' must be strings")
+        thread_id = m["thread_id"].lower()
+        thread_id_tokens = set(re.split(r"[^a-z0-9]+", thread_id))
+        if any(keyword in thread_id_tokens for keyword in _DELETED_PR_AGENT_KEYWORDS):
+            raise ValueError(f"Mission {i} uses a deleted agent in thread_id: {m['thread_id']}")
+        if not any(keyword in thread_id for keyword in _ALLOWED_PR_AGENT_KEYWORDS):
+            raise ValueError(f"Mission {i} does not target an allowed agent: {m['thread_id']}")
     return data
 
 

--- a/src/agentic_explorer/pr_analyzer.py
+++ b/src/agentic_explorer/pr_analyzer.py
@@ -35,6 +35,10 @@ from agentic_explorer.utils.llm_json import extract_yaml_text
 _PR_URL_RE = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)")
 
 MAX_DIFF_CHARS = 100_000
+PR_PROMPT_DIFF_BUDGET_CHARS = int(os.getenv("PR_PROMPT_DIFF_BUDGET_CHARS", "40000"))
+PR_PROMPT_BODY_BUDGET_CHARS = int(os.getenv("PR_PROMPT_BODY_BUDGET_CHARS", "8000"))
+PR_PROMPT_FILE_LIST_LIMIT = int(os.getenv("PR_PROMPT_FILE_LIST_LIMIT", "80"))
+PR_GENERATED_MISSION_PROMPT_MAX_CHARS = int(os.getenv("PR_GENERATED_MISSION_PROMPT_MAX_CHARS", "1200"))
 
 _ALLOWED_PR_AGENT_KEYWORDS = (
     "new_user",
@@ -351,14 +355,71 @@ async def fetch_pr_data(
 # LLM-based mission generation
 # ---------------------------------------------------------------------------
 
-def _format_file_list(files: list[dict[str, Any]]) -> str:
+def _clip_for_prompt(text: str, max_chars: int) -> str:
+    text = text or ""
+    if len(text) <= max_chars:
+        return text
+    if max_chars <= 36:
+        return text[:max(0, max_chars)]
+    return text[: max_chars - 36].rstrip() + f"\n… [truncated {len(text) - max_chars:,} chars]"
+
+
+def _format_file_list(files: list[dict[str, Any]], limit: int = PR_PROMPT_FILE_LIST_LIMIT) -> str:
     lines = []
-    for f in files:
+    for f in files[:limit]:
         name = f["filename"]
         adds = f.get("additions", 0)
         dels = f.get("deletions", 0)
         lines.append(f"- {name} (+{adds}, -{dels})")
+    if len(files) > limit:
+        lines.append(f"- … {len(files) - limit} additional files omitted from prompt budget")
     return "\n".join(lines)
+
+
+def _build_diff_excerpt(diff: str, budget_chars: int = PR_PROMPT_DIFF_BUDGET_CHARS) -> str:
+    """Return a PR diff excerpt that favors file headers and changed hunks.
+
+    The full diff can be fetched and persisted, but scenario generation only needs
+    enough signal to identify UI areas and risk. Keep complete small diffs; for
+    large diffs, allocate a per-file slice so one huge file cannot consume the
+    entire prompt.
+    """
+    if len(diff) <= budget_chars:
+        return diff
+
+    file_sections = re.split(r"(?=^diff --git )", diff, flags=re.MULTILINE)
+    file_sections = [section for section in file_sections if section.strip()]
+    if not file_sections:
+        return _clip_for_prompt(diff, budget_chars)
+
+    per_file_budget = max(1200, budget_chars // max(1, min(len(file_sections), 20)))
+    excerpts: list[str] = []
+    used = 0
+    omitted_files = 0
+
+    for section in file_sections:
+        if used >= budget_chars - 400:
+            omitted_files += 1
+            continue
+        header_lines = []
+        hunk_lines = []
+        for line in section.splitlines():
+            if line.startswith(("diff --git", "index ", "--- ", "+++ ", "@@")):
+                header_lines.append(line)
+            elif line.startswith(("+", "-")) and not line.startswith(("+++", "---")):
+                hunk_lines.append(line)
+        excerpt = "\n".join(header_lines + hunk_lines)
+        excerpt = _clip_for_prompt(excerpt or section, per_file_budget)
+        if used + len(excerpt) > budget_chars - 400:
+            excerpt = _clip_for_prompt(excerpt, max(400, budget_chars - used - 400))
+        excerpts.append(excerpt)
+        used += len(excerpt)
+
+    suffix = (
+        f"\n\n… [diff context disclosed progressively: prompt excerpt is {used:,} chars; "
+        f"full fetched diff was {len(diff):,} chars; omitted {omitted_files} file section(s)]"
+    )
+    return "\n\n".join(excerpts) + suffix
 
 
 _SYSTEM_PROMPT = """\
@@ -380,7 +441,7 @@ It also has 5 advanced agents for deeper coverage:
 
 Each mission has:
   - thread_id: A unique identifier namespaced to this PR (format: pr_{number}_{agent_type}_{nn})
-  - prompt: A detailed, actionable test instruction for the agent
+  - prompt: A concise, actionable test instruction for the agent (max 1200 chars)
 
 Output FORMAT (raw YAML, no code fences):
 
@@ -391,7 +452,7 @@ missions:
 
 Rules:
 1. Generate 3-8 missions depending on the scope of changes.
-2. Each prompt MUST be specific and actionable, referencing concrete UI areas/flows.
+2. Each prompt MUST be concise, specific, and actionable, referencing concrete UI areas/flows.
 3. Map code changes to the MOST relevant remaining agent persona based on the user behavior or risk being tested.
 4. Include at least one explorer/autonomous mission for broad regression coverage.
 5. Thread IDs MUST follow the pattern: pr_{number}_{agenttype}_{nn}
@@ -400,22 +461,24 @@ Rules:
 8. Do NOT use placeholder values — use the actual app name and URL provided.
 9. Each prompt should tell the agent what page to navigate to, what to interact with, \
 and what to verify.
+10. Do not paste code diffs into mission prompts; mention only feature names, paths, or UI risks.
 """
 
 
 def _build_human_message(pr: PRData, app: AppMeta) -> str:
     file_list = _format_file_list(pr.files_changed)
+    diff_excerpt = _build_diff_excerpt(pr.diff)
     return (
         f"## Application Under Test\n"
         f"- Name: {app.name}\n"
         f"- URL: {app.url}\n"
-        f"- Description: {app.description}\n\n"
+        f"- Description: {_clip_for_prompt(app.description or '', 3000)}\n\n"
         f"## Pull Request #{pr.number}\n"
         f"- Title: {pr.title}\n"
         f"- URL: {pr.url}\n\n"
-        f"### PR Description\n{pr.body}\n\n"
+        f"### PR Description\n{_clip_for_prompt(pr.body, PR_PROMPT_BODY_BUDGET_CHARS)}\n\n"
         f"### Files Changed ({len(pr.files_changed)} files)\n{file_list}\n\n"
-        f"### Code Diff\n{pr.diff}\n\n"
+        f"### Code Diff Excerpt\n{diff_excerpt}\n\n"
         f"---\n\n"
         f"Based on these code changes, generate targeted test missions that cover the "
         f"UI areas most likely impacted. Focus on:\n"
@@ -438,7 +501,17 @@ def _validate_missions(data: Any, pr_number: int) -> dict:
             raise ValueError(f"Mission {i} missing 'thread_id' or 'prompt'")
         if not isinstance(m["thread_id"], str) or not isinstance(m["prompt"], str):
             raise ValueError(f"Mission {i} 'thread_id' and 'prompt' must be strings")
+        if len(m["prompt"]) > PR_GENERATED_MISSION_PROMPT_MAX_CHARS:
+            raise ValueError(
+                f"Mission {i} prompt exceeds {PR_GENERATED_MISSION_PROMPT_MAX_CHARS} chars"
+            )
         thread_id = m["thread_id"].lower()
+        expected_prefix = f"pr_{pr_number}_"
+        if not thread_id.startswith(expected_prefix):
+            raise ValueError(
+                f"Mission {i} thread_id must be namespaced to PR #{pr_number} "
+                f"using prefix '{expected_prefix}': {m['thread_id']}"
+            )
         thread_id_tokens = set(re.split(r"[^a-z0-9]+", thread_id))
         if any(keyword in thread_id_tokens for keyword in _DELETED_PR_AGENT_KEYWORDS):
             raise ValueError(f"Mission {i} uses a deleted agent in thread_id: {m['thread_id']}")

--- a/src/agentic_explorer/tools/common/custom_tools.py
+++ b/src/agentic_explorer/tools/common/custom_tools.py
@@ -126,13 +126,15 @@ def _read_text_safe(path: Path, max_chars: int = 20000) -> str:
 
 
 @tool
-def fetch_agent_skill(skill_name: str) -> str:
+def fetch_agent_skill(skill_name: str, include_references: bool = False, reference_path: str = "") -> str:
     """
     Load an installed Agent Skill from the user's local skills directory.
 
     Follows the https://agentskills.io/specification progressive-disclosure model:
       * Always returns the SKILL.md contents.
-      * Appends every Markdown file found recursively under references/.
+      * By default, lists references/ Markdown files without loading them.
+      * Set include_references=true to load references. Use reference_path to
+        load a single reference when only one document is needed.
       * Lists available scripts/ entries (names + exec bits) so the agent can
         decide whether to invoke `run_agent_skill_script`.
       * Lists available assets/ filenames for awareness.
@@ -156,16 +158,55 @@ def fetch_agent_skill(skill_name: str) -> str:
     skill_md = skill_dir / "SKILL.md"
     sections.append("## SKILL.md\n" + _read_text_safe(skill_md))
 
-    # 2. references/ — recursive Markdown documentation
+    # 2. references/ — manifest by default; bodies only on explicit request.
     references_dir = skill_dir / "references"
     if references_dir.is_dir():
         md_files = sorted(p for p in references_dir.rglob("*.md") if p.is_file())
         if md_files:
-            ref_section = ["## references/"]
-            for md in md_files:
-                rel = md.relative_to(skill_dir)
-                ref_section.append(f"### {rel.as_posix()}\n{_read_text_safe(md)}")
-            sections.append("\n\n".join(ref_section))
+            if include_references:
+                requested = reference_path.strip().strip("/")
+                total_ref_bytes = sum(md.stat().st_size for md in md_files)
+                if not requested and total_ref_bytes > 30_000:
+                    ref_entries = [
+                        f"- `{md.relative_to(skill_dir).as_posix()}` ({md.stat().st_size:,} bytes)"
+                        for md in md_files
+                    ]
+                    sections.append(
+                        "## references/\n"
+                        f"References total {total_ref_bytes:,} bytes, so bodies were not bulk-loaded. "
+                        "Call fetch_agent_skill again with include_references=true and "
+                        "reference_path='<one of these paths>'.\n"
+                        + "\n".join(ref_entries)
+                    )
+                    return "\n\n".join(sections)
+                ref_section = ["## references/"]
+                selected = md_files
+                if requested:
+                    candidate = (skill_dir / requested).resolve()
+                    try:
+                        candidate.relative_to(references_dir.resolve())
+                    except ValueError:
+                        return f"Refusing to read reference '{reference_path}': path escapes references/."
+                    if not candidate.is_file():
+                        return f"Reference '{reference_path}' not found in skill '{skill_dir.name}'."
+                    selected = [candidate]
+                for md in selected:
+                    rel = md.relative_to(skill_dir)
+                    ref_section.append(f"### {rel.as_posix()}\n{_read_text_safe(md, max_chars=12000)}")
+                sections.append("\n\n".join(ref_section))
+            else:
+                ref_entries = []
+                for md in md_files:
+                    rel = md.relative_to(skill_dir).as_posix()
+                    size = md.stat().st_size
+                    ref_entries.append(f"- `{rel}` ({size:,} bytes)")
+                sections.append(
+                    "## references/\n"
+                    "Reference bodies are not loaded by default to conserve context. "
+                    "Call fetch_agent_skill with include_references=true and, preferably, "
+                    "reference_path='<one of these paths>' when details are needed.\n"
+                    + "\n".join(ref_entries)
+                )
 
     # 3. scripts/ — list with exec info (bodies are NOT loaded, per progressive disclosure)
     scripts_dir = skill_dir / "scripts"

--- a/tests/test_browser_engine.py
+++ b/tests/test_browser_engine.py
@@ -1,0 +1,115 @@
+import os
+import tempfile
+import unittest
+
+from agentic_explorer.tools.browser import engine
+
+
+class BrowserEngineTests(unittest.TestCase):
+    def test_validate_selector_allows_resilient_selectors(self):
+        stable_selectors = [
+            "[data-test-subj='submitButton']",
+            "[aria-label='Search']",
+            "button:has-text('Save')",
+            "role=button[name='Submit']",
+            "text='Apply'",
+        ]
+
+        for selector in stable_selectors:
+            with self.subTest(selector=selector):
+                self.assertIsNone(engine._validate_selector(selector))
+
+    def test_validate_selector_rejects_xpath_and_positional_css(self):
+        brittle_selectors = [
+            "//button[@type='submit']",
+            "/html/body/div/button",
+            "button:nth-child(2)",
+            "li:nth-of-type(3)",
+            "main > div > span[data-test-subj='late']",
+        ]
+
+        for selector in brittle_selectors:
+            with self.subTest(selector=selector):
+                error = engine._validate_selector(selector)
+                self.assertIsNotNone(error)
+                self.assertIn("BRITTLE_SELECTOR_REJECTED", error)
+
+    def test_ts_escape_handles_quotes_backslashes_and_newlines(self):
+        self.assertEqual(engine._ts_escape("a'b\\c\nnext\r"), "a\\'b\\\\c\\nnext\\r")
+
+    def test_tape_entry_to_ts_keeps_failed_actions_as_comments(self):
+        entry = {
+            "action": "click",
+            "params": {"selector": "[data-test-subj='missing']"},
+            "ok": False,
+            "error": "Timeout\nline two",
+        }
+
+        ts = engine._tape_entry_to_ts(entry)
+
+        self.assertIn("FAILED AT RECORD TIME", ts)
+        self.assertIn("Timeout", ts)
+        self.assertIn("await page.click('[data-test-subj=\\'missing\\']');", ts)
+
+    def test_tape_entry_to_ts_covers_supported_actions(self):
+        cases = [
+            ({"action": "navigate", "params": {"url": "https://app.example"}, "ok": True}, "page.goto"),
+            ({"action": "fill", "params": {"selector": "input", "value": "abc"}, "ok": True}, "page.fill"),
+            ({"action": "press", "params": {"selector": "input", "key": "Enter"}, "ok": True}, "page.press"),
+            ({"action": "select_option", "params": {"selector": "select", "value": "x"}, "ok": True}, "page.selectOption"),
+            ({"action": "hover", "params": {"selector": "button"}, "ok": True}, "page.hover"),
+            ({"action": "wait_for", "params": {"selector": "main", "state": "attached"}, "ok": True}, "page.waitForSelector"),
+            ({"action": "scroll", "params": {"selector": "section"}, "ok": True}, "scrollIntoViewIfNeeded"),
+            ({"action": "scroll", "params": {"y": 250}, "ok": True}, "window.scrollBy"),
+            ({"action": "extract_text", "params": {"selector": "h1"}, "ok": True}, "expect(_t.length)"),
+            ({"action": "snapshot", "params": {}, "ok": True}, "snapshot"),
+            ({"action": "check_page_health", "params": {}, "ok": True}, "check_page_health"),
+        ]
+
+        for entry, expected in cases:
+            with self.subTest(action=entry["action"], params=entry["params"]):
+                self.assertIn(expected, engine._tape_entry_to_ts(entry))
+
+    def test_generate_playwright_spec_writes_replay_from_action_tape(self):
+        thread_id = "unit_browser_engine"
+        original_cwd = os.getcwd()
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                os.chdir(tmp)
+                engine._ACTION_TAPES[thread_id] = [
+                    {
+                        "ts": 1.0,
+                        "action": "navigate",
+                        "params": {"url": "https://app.example/home"},
+                        "ok": True,
+                    },
+                    {
+                        "ts": 2.0,
+                        "action": "click",
+                        "params": {"selector": "[data-test-subj='save']"},
+                        "ok": True,
+                    },
+                ]
+
+                spec_path = engine.generate_playwright_spec(
+                    thread_id,
+                    "Save button fails */ safely",
+                    app_url="https://app.example",
+                )
+
+                self.assertTrue(os.path.isabs(spec_path))
+                self.assertTrue(os.path.exists(spec_path))
+                with open(spec_path, encoding="utf-8") as fh:
+                    content = fh.read()
+                self.assertIn("Auto-generated reproduction", content)
+                self.assertIn("Save button fails * / safely", content)
+                self.assertIn("await page.goto('https://app.example/home');", content)
+                self.assertIn("await page.click('[data-test-subj=\\'save\\']');", content)
+                self.assertIn("storageState: 'auth.json'", content)
+            finally:
+                os.chdir(original_cwd)
+                engine._ACTION_TAPES.pop(thread_id, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,111 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from agentic_explorer.config import AppConfig, _interpolate, load_app_config
+
+
+class ConfigTests(unittest.TestCase):
+    def setUp(self):
+        self._original_cwd = os.getcwd()
+
+    def tearDown(self):
+        os.chdir(self._original_cwd)
+
+    def test_interpolate_replaces_nested_env_values_and_missing_with_blank(self):
+        with patch.dict(os.environ, {"APP_URL": "https://app.example", "TOKEN": "secret"}, clear=False):
+            result = _interpolate({
+                "app": {"url": "${APP_URL}", "missing": "${DOES_NOT_EXIST}"},
+                "headers": ["Bearer ${TOKEN}"],
+                "unchanged": 3,
+            })
+
+        self.assertEqual(result["app"]["url"], "https://app.example")
+        self.assertEqual(result["app"]["missing"], "")
+        self.assertEqual(result["headers"], ["Bearer secret"])
+        self.assertEqual(result["unchanged"], 3)
+
+    def test_load_app_config_returns_defaults_when_file_missing(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(os.environ, {"APP_URL": "https://fallback.example"}, clear=False):
+            os.chdir(tmp)
+            missing = Path(tmp) / "missing.yaml"
+
+            cfg = load_app_config(missing)
+
+        self.assertIsInstance(cfg, AppConfig)
+        self.assertEqual(cfg.app.name, "Web Application")
+        self.assertEqual(cfg.app.url, "https://fallback.example")
+        self.assertEqual(cfg.auth.method, "form")
+
+    def test_load_app_config_parses_nested_yaml_and_env_interpolation(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {
+                "APP_URL": "https://env.example",
+                "MCP_SERVERS_CONFIG": "/env/mcp.json",
+                "AGENT_SKILLS_ROOT": "/env/skills",
+            },
+            clear=False,
+        ):
+            os.chdir(tmp)
+            config_path = Path(tmp) / "config.yaml"
+            config_path.write_text(
+                """
+app:
+  name: Test App
+  url: ${APP_URL}
+  description: Product under test
+auth:
+  method: form
+  selectors:
+    username: '[data-test-subj="username"]'
+    password: '[data-test-subj="password"]'
+  post_login_check: '[data-test-subj="home"]'
+paths:
+  mcp_servers: /project/mcp.json
+  skills_root: /project/skills
+llm:
+  provider: gemini
+  gemini_model: gemini-test
+  claude_model: claude-test
+  gemini_vision_model: gemini-vision-test
+  claude_vision_model: claude-vision-test
+""".strip(),
+                encoding="utf-8",
+            )
+
+            cfg = load_app_config(config_path)
+
+        self.assertEqual(cfg.app.name, "Test App")
+        self.assertEqual(cfg.app.url, "https://env.example")
+        self.assertEqual(cfg.app.description, "Product under test")
+        self.assertEqual(cfg.auth.selectors["username"], '[data-test-subj="username"]')
+        self.assertEqual(cfg.auth.post_login_check, '[data-test-subj="home"]')
+        self.assertEqual(cfg.paths.mcp_servers, "/project/mcp.json")
+        self.assertEqual(cfg.paths.skills_root, "/project/skills")
+        self.assertEqual(cfg.llm.provider, "gemini")
+        self.assertEqual(cfg.llm.gemini_model, "gemini-test")
+        self.assertEqual(cfg.llm.claude_model, "claude-test")
+        self.assertEqual(cfg.llm.gemini_vision_model, "gemini-vision-test")
+        self.assertEqual(cfg.llm.claude_vision_model, "claude-vision-test")
+
+    def test_load_app_config_uses_env_paths_when_yaml_paths_missing(self):
+        with tempfile.TemporaryDirectory() as tmp, patch.dict(
+            os.environ,
+            {"MCP_SERVERS_CONFIG": "/env/mcp.json", "AGENT_SKILLS_ROOT": "/env/skills"},
+            clear=False,
+        ):
+            os.chdir(tmp)
+            config_path = Path(tmp) / "config.yaml"
+            config_path.write_text("app:\n  name: Env Paths\n", encoding="utf-8")
+
+            cfg = load_app_config(config_path)
+
+        self.assertEqual(cfg.paths.mcp_servers, "/env/mcp.json")
+        self.assertEqual(cfg.paths.skills_root, "/env/skills")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_context_disclosure.py
+++ b/tests/test_context_disclosure.py
@@ -1,0 +1,110 @@
+import unittest
+from typing import cast
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from agentic_explorer.config import AppMeta
+from agentic_explorer.main import _bound_transcript_for_report, REPORT_TRANSCRIPT_MAX_CHARS
+from agentic_explorer.orchestration.graph_base import AgentState, _build_routing_context
+from agentic_explorer.pr_analyzer import (
+    PRData,
+    PR_GENERATED_MISSION_PROMPT_MAX_CHARS,
+    _build_diff_excerpt,
+    _build_human_message,
+    _validate_missions,
+)
+
+
+class ContextDisclosureTests(unittest.TestCase):
+    def test_report_transcript_at_limit_is_unchanged(self):
+        transcript = "x" * REPORT_TRANSCRIPT_MAX_CHARS
+        self.assertEqual(_bound_transcript_for_report(transcript), transcript)
+
+    def test_report_transcript_is_bounded(self):
+        transcript = "start\n" + ("middle\n" * 10_000) + "end"
+        bounded = _bound_transcript_for_report(transcript)
+        self.assertLessEqual(len(bounded), REPORT_TRANSCRIPT_MAX_CHARS)
+        self.assertIn("start", bounded)
+        self.assertIn("end", bounded)
+        self.assertIn("omitted", bounded)
+
+    def test_supervisor_context_uses_recent_progress_not_full_history(self):
+        old = HumanMessage(content="old detail " * 500)
+        recent = AIMessage(content="recent decision")
+        tool = ToolMessage(content="clicked stable selector", name="execute_browser_command", tool_call_id="1")
+        state = {
+            "messages": [HumanMessage(content="mission objective"), old, recent, tool],
+            "next_agent": "",
+            "step_count": 1,
+            "action_tape": [{"action": "click", "params": {"selector": "[data-test-subj='x']"}, "ok": True}],
+            "bugs_found": [],
+            "explored_paths": ["https://app.example/path"],
+        }
+        context = _build_routing_context(cast(AgentState, cast(object, state)), [])
+        self.assertIn("MISSION", context)
+        self.assertIn("RECENT_PROGRESS", context)
+        self.assertIn("recent decision", context)
+        self.assertLess(len(context), 8_000)
+
+    def test_supervisor_context_truncates_long_bug_and_deduplicates_paths(self):
+        state = {
+            "messages": [HumanMessage(content="mission objective")],
+            "next_agent": "",
+            "step_count": 1,
+            "action_tape": [],
+            "bugs_found": ["bug " + ("detail " * 200)],
+            "explored_paths": ["https://app.example/a", "https://app.example/a", "https://app.example/b"],
+        }
+
+        context = _build_routing_context(cast(AgentState, cast(object, state)), [])
+
+        self.assertIn("BUGS_FOUND", context)
+        self.assertIn("… [truncated]", context)
+        self.assertEqual(context.count("https://app.example/a"), 1)
+        self.assertIn("https://app.example/b", context)
+
+    def test_pr_human_message_uses_diff_excerpt(self):
+        huge_diff = "".join(
+            f"diff --git a/file{i}.py b/file{i}.py\n@@ -1 +1 @@\n-old{i}\n+new{i}\n"
+            for i in range(2_000)
+        )
+        pr = PRData(
+            owner="o",
+            repo="r",
+            number=123,
+            title="Change UI",
+            body="body",
+            diff=huge_diff,
+            files_changed=[{"filename": f"file{i}.py", "additions": 1, "deletions": 1} for i in range(120)],
+            url="https://github.com/o/r/pull/123",
+        )
+        app = AppMeta(name="App", url="https://app.example", description="desc")
+        message = _build_human_message(pr, app)
+        self.assertIn("Code Diff Excerpt", message)
+        self.assertIn("additional files omitted", message)
+        self.assertLess(len(message), len(huge_diff) + 1_000)
+
+    def test_diff_excerpt_respects_small_budget(self):
+        diff = "diff --git a/a.py b/a.py\n@@ -1 +1 @@\n" + ("-old\n+new\n" * 5000)
+        excerpt = _build_diff_excerpt(diff, budget_chars=4_000)
+        self.assertIn("diff context disclosed progressively", excerpt)
+        self.assertLess(len(excerpt), 5_000)
+
+    def test_pr_mission_validation_rejects_oversized_prompt(self):
+        with self.assertRaises(ValueError):
+            _validate_missions(
+                {
+                    "missions": [
+                        {
+                            "thread_id": "pr_123_new_user_01",
+                            "prompt": "x" * (PR_GENERATED_MISSION_PROMPT_MAX_CHARS + 1),
+                        }
+                    ]
+                },
+                123,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_llm_json.py
+++ b/tests/test_llm_json.py
@@ -1,0 +1,46 @@
+import unittest
+
+from agentic_explorer.utils.llm_json import (
+    extract_json_text,
+    extract_yaml_text,
+    normalize_llm_text,
+    parse_json_from_llm,
+)
+
+
+class LLMJsonTests(unittest.TestCase):
+    def test_normalize_llm_text_handles_string_list_blocks_and_fallback(self):
+        self.assertEqual(normalize_llm_text("plain"), "plain")
+        self.assertEqual(
+            normalize_llm_text(["a", {"text": "b"}, {"not_text": "ignored"}, "c"]),
+            "abc",
+        )
+        self.assertEqual(normalize_llm_text(123), "123")
+
+    def test_extract_json_text_prefers_json_fence(self):
+        content = "Intro\n```json\n{\"ok\": true}\n```\nOutro"
+
+        self.assertEqual(extract_json_text(content), '{"ok": true}')
+
+    def test_extract_json_text_uses_first_generic_fence(self):
+        content = "Before\n```\n{\"value\": 1}\n```\nAfter"
+
+        self.assertEqual(extract_json_text(content), '{"value": 1}')
+
+    def test_parse_json_from_llm_parses_normalized_content(self):
+        self.assertEqual(parse_json_from_llm([{"text": "```json\n{\"a\": 2}\n```"}]), {"a": 2})
+
+    def test_extract_yaml_text_prefers_yaml_fence(self):
+        content = "Intro\n```yaml\nmissions:\n  - thread_id: pr_1_new_user_01\n```\nOutro"
+
+        self.assertEqual(
+            extract_yaml_text(content),
+            "missions:\n  - thread_id: pr_1_new_user_01",
+        )
+
+    def test_extract_yaml_text_returns_trimmed_plain_text_without_fence(self):
+        self.assertEqual(extract_yaml_text("  missions: []\n"), "missions: []")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pr_analyzer.py
+++ b/tests/test_pr_analyzer.py
@@ -1,0 +1,142 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from agentic_explorer.pr_analyzer import (
+    _find_github_server,
+    _parse_files_text,
+    _parse_pr_metadata,
+    _validate_missions,
+    parse_pr_url,
+)
+
+
+class PRAnalyzerTests(unittest.TestCase):
+    def test_parse_pr_url_accepts_nested_url_parts(self):
+        owner, repo, number = parse_pr_url("https://github.com/org/repo-name/pull/456/files")
+
+        self.assertEqual(owner, "org")
+        self.assertEqual(repo, "repo-name")
+        self.assertEqual(number, 456)
+
+    def test_parse_pr_url_rejects_non_pr_url(self):
+        with self.assertRaisesRegex(ValueError, "Expected format"):
+            parse_pr_url("https://github.com/org/repo/issues/456")
+
+    def test_find_github_server_supports_mcp_servers_transport_shape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "mcp_servers.json"
+            config_path.write_text(
+                json.dumps({
+                    "mcpServers": {
+                        "github": {
+                            "transport": "http",
+                            "url": "https://api.githubcopilot.com/mcp/",
+                        }
+                    }
+                }),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                _find_github_server(config_path),
+                {
+                    "github": {
+                        "transport": "http",
+                        "url": "https://api.githubcopilot.com/mcp/",
+                    }
+                },
+            )
+
+    def test_find_github_server_normalizes_servers_type_shape(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config_path = Path(tmp) / "mcp_servers.json"
+            config_path.write_text(
+                json.dumps({
+                    "servers": {
+                        "my-github-server": {
+                            "type": "http",
+                            "url": "https://example.test/mcp",
+                        }
+                    }
+                }),
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                _find_github_server(config_path),
+                {"my-github-server": {"transport": "http", "url": "https://example.test/mcp"}},
+            )
+
+    def test_parse_pr_metadata_handles_json_labels(self):
+        title, body, labels = _parse_pr_metadata(json.dumps({
+            "title": "Improve filters",
+            "body": "Adds advanced filtering.",
+            "labels": [{"name": "ui"}, "qa"],
+        }))
+
+        self.assertEqual(title, "Improve filters")
+        self.assertEqual(body, "Adds advanced filtering.")
+        self.assertEqual(labels, ["ui", "qa"])
+
+    def test_parse_pr_metadata_falls_back_to_first_line_title(self):
+        title, body, labels = _parse_pr_metadata("Title line\nLong body")
+
+        self.assertEqual(title, "Title line")
+        self.assertEqual(body, "Title line\nLong body")
+        self.assertEqual(labels, [])
+
+    def test_parse_files_text_handles_json_and_plain_text(self):
+        self.assertEqual(
+            _parse_files_text(json.dumps([
+                {"filename": "src/app.py", "additions": 10, "deletions": 2},
+                {"path": "src/other.py"},
+            ])),
+            [
+                {"filename": "src/app.py", "additions": 10, "deletions": 2},
+                {"filename": "src/other.py", "additions": 0, "deletions": 0},
+            ],
+        )
+        self.assertEqual(
+            _parse_files_text("- src/app.py\n- src/other.py"),
+            [
+                {"filename": "src/app.py", "additions": 0, "deletions": 0},
+                {"filename": "src/other.py", "additions": 0, "deletions": 0},
+            ],
+        )
+
+    def test_validate_missions_accepts_allowed_pr_thread_id(self):
+        data = {
+            "missions": [
+                {"thread_id": "pr_123_new_user_01", "prompt": "Verify the updated onboarding flow."},
+                {"thread_id": "pr_123_explorer_02", "prompt": "Explore adjacent regressions."},
+            ]
+        }
+
+        self.assertIs(_validate_missions(data, 123), data)
+
+    def test_validate_missions_rejects_wrong_pr_namespace(self):
+        with self.assertRaisesRegex(ValueError, "pr_123"):
+            _validate_missions(
+                {"missions": [{"thread_id": "pr_999_new_user_01", "prompt": "Verify flow."}]},
+                123,
+            )
+
+    def test_validate_missions_rejects_deleted_agent_keyword_token(self):
+        with self.assertRaisesRegex(ValueError, "deleted agent"):
+            _validate_missions(
+                {"missions": [{"thread_id": "pr_123_listing_01", "prompt": "Verify listing."}]},
+                123,
+            )
+
+    def test_validate_missions_rejects_unknown_agent_keyword(self):
+        with self.assertRaisesRegex(ValueError, "allowed agent"):
+            _validate_missions(
+                {"missions": [{"thread_id": "pr_123_unknown_01", "prompt": "Verify flow."}]},
+                123,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request updates the documentation to reflect major changes in the agent architecture and developer workflows. The standard QA swarm has been simplified from 13 agents (including UI-pattern specialists) to 3 core behavioral personas, while advanced testing agents now cover accessibility, data-heavy, impatient, returning user, and explorer scenarios. References to vision/AI validation have been replaced with screenshot and reproduction tooling. The documentation and diagrams have been updated for accuracy and clarity, and new conventions and configuration options are described.

**Agent architecture and documentation updates:**

- Reduced the standard QA agents from 13 (with UI-pattern specialists) to 3 core behavioral personas (`new_user_agent`, `power_user_agent`, `adversarial_user_agent`). Advanced agents now include `accessibility_user_agent`, `data_heavy_user_agent`, `impatient_user_agent`, `returning_user_agent`, and `explorer_agent`. All diagrams, lists, and mission templates have been updated accordingly. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L60-R79) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R57) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R129) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L338-R369)
- Updated the agent routing logic and documentation to clarify that `accessibility`, `data_heavy`, `impatient`, `returning`, `explorer`, `chaos`, and `autonomous` keywords trigger the advanced graph, while all others use the standard persona swarm. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L39-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R83)

**Developer workflow and configuration changes:**

- Updated sample commands and mission templates throughout the documentation to use the new agent names and reflect the reduced agent set. (F91855fcL143R143, [README.mdL338-R369](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L338-R369))
- Added new configuration environment variables, including `ANTHROPIC_VERTEX_REGION` and a provider-agnostic `SCENARIO_MODEL`, and clarified the configuration surface.

**Tooling and feature clarifications:**

- Replaced references to "visual validation" and AI vision models with screenshot capture and Playwright reproduction tooling for bug evidence. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L132-R133) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R98) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L144-R139)
- Added a new "Context Disclosure Rule" to the conventions section, specifying how prompts and context should be managed for efficiency and clarity.

**Contribution and maintenance guidelines:**

- Updated agent modification instructions to require updating the agent registry and supervisor descriptions, not just the tool bundle and routing table. Clarified requirements for PR analyzer and mission validation when adding new agents.

**Reference:**  
[[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L39-R40) [[2]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L60-R79) [[3]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L101-R94) [[4]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L132-R133) F91855fcL143R143, [[5]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9R173-R181) [[6]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L191-R199) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R57) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72) [[9]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L87-R83) [[10]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R98) [[11]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L123-R129) [[12]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L144-R139) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L338-R369)